### PR TITLE
Read enums and write additional metadata

### DIFF
--- a/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
@@ -7,7 +7,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.util.Models;
 
 import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
 import ch.unisg.ics.interactions.wot.td.affordances.PropertyAffordance;
@@ -218,7 +225,22 @@ public class ThingDescription {
     }
     
     public Builder addGraph(Model graph) {
-      this.graph = Optional.of(graph);
+    	if (this.graph.isPresent()) {
+    		this.graph.get().addAll(graph);
+    	}
+    	else {
+    		this.graph = Optional.of(graph);
+    	}
+      return this;
+    }
+    
+    public Builder addStatement(Resource subject, IRI predicate, Value object) {
+      if (this.graph.isPresent()) {
+      	this.graph.get().add(subject, predicate, object);
+      }
+      else {
+    	  this.graph = Optional.of(new ModelBuilder().add(subject, predicate, object).build());
+      }
       return this;
     }
     

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
@@ -10,11 +10,8 @@ import java.util.stream.Collectors;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
-import org.eclipse.rdf4j.model.util.Models;
 
 import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
 import ch.unisg.ics.interactions.wot.td.affordances.PropertyAffordance;
@@ -225,22 +222,22 @@ public class ThingDescription {
     }
     
     public Builder addGraph(Model graph) {
-    	if (this.graph.isPresent()) {
-    		this.graph.get().addAll(graph);
-    	}
-    	else {
-    		this.graph = Optional.of(graph);
-    	}
+      if (this.graph.isPresent()) {
+        this.graph.get().addAll(graph);
+      } else {
+        this.graph = Optional.of(graph);
+      }
+      
       return this;
     }
     
     public Builder addTriple(Resource subject, IRI predicate, Value object) {
       if (this.graph.isPresent()) {
-      	this.graph.get().add(subject, predicate, object);
+        this.graph.get().add(subject, predicate, object);
+      } else {
+        this.graph = Optional.of(new ModelBuilder().add(subject, predicate, object).build());
       }
-      else {
-    	  this.graph = Optional.of(new ModelBuilder().add(subject, predicate, object).build());
-      }
+      
       return this;
     }
     

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
@@ -234,7 +234,7 @@ public class ThingDescription {
       return this;
     }
     
-    public Builder addStatement(Resource subject, IRI predicate, Value object) {
+    public Builder addTriple(Resource subject, IRI predicate, Value object) {
       if (this.graph.isPresent()) {
       	this.graph.get().add(subject, predicate, object);
       }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/io/SchemaGraphReader.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/io/SchemaGraphReader.java
@@ -166,7 +166,7 @@ class SchemaGraphReader {
     
     return Optional.of(builder.build());
   }
-    
+  
   @SuppressWarnings({ "rawtypes", "unchecked" })
   private void readDataSchemaMetadata(DataSchema.Builder builder, Resource schemaId) {
     /* Read semantic types (IRIs) */
@@ -179,7 +179,8 @@ class SchemaGraphReader {
     builder.addSemanticTypes(semTags);
     
     /* Read enumeration */
-    Set<String> enumeration = Models.objectStrings(model.filter(schemaId, rdf.createIRI(JSONSchema.enumeration), null));
+    Set<String> enumeration = Models.objectStrings(model.filter(schemaId, 
+        rdf.createIRI(JSONSchema.enumeration), null));
     builder.addEnum(enumeration);
   }
   

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/io/SchemaGraphReader.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/io/SchemaGraphReader.java
@@ -46,7 +46,7 @@ class SchemaGraphReader {
         return readArraySchema(schemaId);
       } else if (types.contains(rdf.createIRI(JSONSchema.BooleanSchema))) {
         BooleanSchema.Builder builder = new BooleanSchema.Builder();
-        readSemanticTypesForDataSchema(builder, schemaId);
+        readDataSchemaMetadata(builder, schemaId);
         return Optional.of(builder.build());
       } else if (types.contains(rdf.createIRI(JSONSchema.NumberSchema))) {
         return readNumberSchema(schemaId);
@@ -54,11 +54,11 @@ class SchemaGraphReader {
         return readIntegerSchema(schemaId);
       } else if (types.contains(rdf.createIRI(JSONSchema.StringSchema))) {
         StringSchema.Builder builder = new StringSchema.Builder();
-        readSemanticTypesForDataSchema(builder, schemaId);
+        readDataSchemaMetadata(builder, schemaId);
         return Optional.of(builder.build());
       } else if (types.contains(rdf.createIRI(JSONSchema.NullSchema))) {
         NullSchema.Builder builder = new NullSchema.Builder();
-        readSemanticTypesForDataSchema(builder, schemaId);
+        readDataSchemaMetadata(builder, schemaId);
         return Optional.of(builder.build());
       }
     }
@@ -68,7 +68,7 @@ class SchemaGraphReader {
   
   private Optional<DataSchema> readObjectSchema(Resource schemaId) {
     ObjectSchema.Builder builder = new ObjectSchema.Builder();
-    readSemanticTypesForDataSchema(builder, schemaId);
+    readDataSchemaMetadata(builder, schemaId);
     
     /* Read properties */
     Set<Resource> propertyIds = Models.objectResources(model.filter(schemaId, 
@@ -98,7 +98,7 @@ class SchemaGraphReader {
   
   private Optional<DataSchema> readArraySchema(Resource schemaId) {
     ArraySchema.Builder builder = new ArraySchema.Builder();
-    readSemanticTypesForDataSchema(builder, schemaId);
+    readDataSchemaMetadata(builder, schemaId);
     
     /* Read minItems */
     Optional<Literal> minItems = Models.objectLiteral(model.filter(schemaId, 
@@ -130,7 +130,7 @@ class SchemaGraphReader {
   private Optional<DataSchema> readIntegerSchema(Resource schemaId) {
     IntegerSchema.Builder builder = new IntegerSchema.Builder();
     
-    readSemanticTypesForDataSchema(builder, schemaId);
+    readDataSchemaMetadata(builder, schemaId);
     
     Optional<Literal> maximum = Models.objectLiteral(model.filter(schemaId, 
         rdf.createIRI(JSONSchema.maximum), null));
@@ -150,7 +150,7 @@ class SchemaGraphReader {
   private Optional<DataSchema> readNumberSchema(Resource schemaId) {
     NumberSchema.Builder builder = new NumberSchema.Builder();
     
-    readSemanticTypesForDataSchema(builder, schemaId);
+    readDataSchemaMetadata(builder, schemaId);
     
     Optional<Literal> maximum = Models.objectLiteral(model.filter(schemaId, 
         rdf.createIRI(JSONSchema.maximum), null));
@@ -166,9 +166,9 @@ class SchemaGraphReader {
     
     return Optional.of(builder.build());
   }
-  
+    
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  private void readSemanticTypesForDataSchema(DataSchema.Builder builder, Resource schemaId) {
+  private void readDataSchemaMetadata(DataSchema.Builder builder, Resource schemaId) {
     /* Read semantic types (IRIs) */
     Set<IRI> semIRIs = Models.objectIRIs(model.filter(schemaId, RDF.TYPE, null));
     builder.addSemanticTypes(semIRIs.stream().map(iri -> iri.stringValue())
@@ -177,5 +177,10 @@ class SchemaGraphReader {
     /* Read semantic types (strings) */
     Set<String> semTags = Models.objectStrings(model.filter(schemaId, RDF.TYPE, null));
     builder.addSemanticTypes(semTags);
+    
+    /* Read enumeration */
+    Set<String> enumeration = Models.objectStrings(model.filter(schemaId, rdf.createIRI(JSONSchema.enumeration), null));
+    builder.addEnum(enumeration);
   }
+  
 }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReader.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReader.java
@@ -124,10 +124,15 @@ public class TDGraphReader {
   }
   
   String readThingTitle() {
-    Optional<Literal> thingTitle = Models.objectLiteral(model.filter(thingId, 
-        rdf.createIRI(DCT.title), null));
+  	Literal thingTitle;
+  	
+    try {
+    	thingTitle = Models.objectLiteral(model.filter(thingId, rdf.createIRI(DCT.title), null)).get();    	
+    } catch (NoSuchElementException e) {
+    	throw new InvalidTDException("Missing mandatory title.", e);
+    }
     
-    return thingTitle.get().stringValue();
+    return thingTitle.stringValue();
   }
   
   Set<String> readThingTypes() {

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReader.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReader.java
@@ -127,9 +127,9 @@ public class TDGraphReader {
   	Literal thingTitle;
   	
     try {
-    	thingTitle = Models.objectLiteral(model.filter(thingId, rdf.createIRI(DCT.title), null)).get();    	
+      thingTitle = Models.objectLiteral(model.filter(thingId, rdf.createIRI(DCT.title), null)).get();    	
     } catch (NoSuchElementException e) {
-    	throw new InvalidTDException("Missing mandatory title.", e);
+      throw new InvalidTDException("Missing mandatory title.", e);
     }
     
     return thingTitle.stringValue();

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriter.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriter.java
@@ -61,6 +61,7 @@ public class TDGraphWriter {
         .addBaseURI()
         .addProperties()
         .addActions()
+        .addGraph()
         .write(RDFFormat.TURTLE);
   }
   
@@ -140,6 +141,17 @@ public class TDGraphWriter {
     }
     
     return this;
+  }
+  
+  private TDGraphWriter addGraph() {
+  	if(td.getGraph().isPresent()) {
+  		getModel().addAll(td.getGraph().get());
+  		
+  		td.getGraph().get().getNamespaces().stream()
+  		    .filter(ns -> !getModel().getNamespace(ns.getPrefix()).isPresent())
+          .forEach(graphBuilder::setNamespace);
+  	}
+  	return this;
   }
   
   private Resource addAffordance(InteractionAffordance affordance, String affordanceProp, 

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/SchemaGraphReaderTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/SchemaGraphReaderTest.java
@@ -64,6 +64,7 @@ public class SchemaGraphReaderTest {
         "    js:properties [\n" + 
         "        a js:StringSchema, <http://example.org/#SemString> ;\n" +
         "        js:propertyName \"string_value\";\n" +
+        "		 js:enum \"label1\", <http://example.org/label2>, \"label3\" ;\n" +
         "    ] ;\n" +
         "    js:properties [\n" + 
         "        a js:NullSchema, <http://example.org/#SemNull> ;\n" +
@@ -89,6 +90,9 @@ public class SchemaGraphReaderTest {
     DataSchema stringProperty = object.getProperties().get("string_value");
     assertEquals(DataSchema.STRING, stringProperty.getDatatype());
     assertTrue(stringProperty.getSemanticTypes().contains(PREFIX + "SemString"));
+    assertEquals(3,stringProperty.getEnumeration().size());
+    assertTrue(stringProperty.getEnumeration().contains("label1"));
+    assertTrue(stringProperty.getEnumeration().contains("http://example.org/label2"));
     
     DataSchema nullProperty = object.getProperties().get("null_value");
     assertEquals(DataSchema.NULL, nullProperty.getDatatype());
@@ -270,6 +274,7 @@ public class SchemaGraphReaderTest {
     assertEquals(DataSchema.OBJECT, array.getItems().get(0).getDatatype());
     assertEquals(DataSchema.OBJECT, array.getItems().get(1).getDatatype());
   }
+  
   
   private ObjectSchema assertObjectMetadata(String testSemObject, String semType, int props, int req) 
       throws RDFParseException, RDFHandlerException, IOException {

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReaderTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReaderTest.java
@@ -2,11 +2,13 @@ package ch.unisg.ics.interactions.wot.td.io;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.NoSuchElementException;
 
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.junit.Test;
@@ -512,6 +514,26 @@ public class TDGraphReaderTest {
     
     assertEquals(DataSchema.BOOLEAN, output.getProperties().get("boolean_value").getDatatype());
     assertTrue(output.getRequiredProperties().contains("boolean_value"));
+  }
+  
+  @Test
+  public void testMissingMandatoryTitle() {
+  	String testTDWithMissingTitle =
+  	    "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+  			"@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
+  			"\n" +
+  			"<http://example.org/#thing> a td:Thing ;\n" + 
+  			"    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
+  			"    td:hasBase <http://example.org/> .\n" ;
+  	
+  	Exception exception = assertThrows(InvalidTDException.class, () -> {
+  		TDGraphReader.readFromString(TDFormat.RDF_TURTLE, testTDWithMissingTitle);
+    });
+  	
+  	String expectedMessage = "Missing mandatory title.";
+    String actualMessage = exception.getMessage();
+ 
+    assertTrue(actualMessage.contains(expectedMessage));	
   }
   
   private void assertForm(Form form, String methodName, String target, 

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
@@ -308,8 +308,7 @@ public class TDGraphWriterTest {
   	    .addStatement(protocolId, rdf.createIRI(NS,"hasLanguage"), rdf.createIRI("http://jason.sourceforge.net/wp/description/"))
   	    .build();
         
-        assertIsomorphicGraphs(testTD, td);
-      
+    assertIsomorphicGraphs(testTD, td);    
   }
   
   @Test
@@ -376,11 +375,7 @@ public class TDGraphWriterTest {
     Model tdModel = ReadWriteTestUtils.readModelFromString(RDFFormat.TURTLE, description, 
         IO_BASE_IRI);
     
-    System.out.println(expectedModel);
-    System.out.println("\n");
-    System.out.println(tdModel);
-    
     assertTrue(Models.isomorphic(expectedModel, tdModel));
-    
+   
   }
 }

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
@@ -11,7 +11,6 @@ import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.Models;
-import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -299,13 +298,13 @@ public class TDGraphWriterTest {
   	ThingDescription td = (new ThingDescription.Builder("My Lamp Thing"))
   	    .addThingURI("http://example.org/lamp123")
   	    .addSemanticType("https://w3id.org/saref#LightSwitch")
-  	    .addStatement(protocolId, RDF.TYPE, rdf.createIRI(NS, "UsageProtocol"))
-  	    .addStatement(protocolId, DCTERMS.TITLE, rdf.createLiteral("Party Light"))
+  	    .addTriple(protocolId, RDF.TYPE, rdf.createIRI(NS, "UsageProtocol"))
+  	    .addTriple(protocolId, DCTERMS.TITLE, rdf.createLiteral("Party Light"))
   	    .addGraph(metadata)
   	    .addGraph(new ModelBuilder()
   	    				.add(manualId, rdf.createIRI(NS, "hasUsageProtocol"), protocolId)
   	    				.build())  	    
-  	    .addStatement(protocolId, rdf.createIRI(NS,"hasLanguage"), rdf.createIRI("http://jason.sourceforge.net/wp/description/"))
+  	    .addTriple(protocolId, rdf.createIRI(NS,"hasLanguage"), rdf.createIRI("http://jason.sourceforge.net/wp/description/"))
   	    .build();
         
     assertIsomorphicGraphs(testTD, td);    

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
@@ -4,8 +4,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
+import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.DC;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
@@ -262,6 +270,49 @@ public class TDGraphWriterTest {
   }
   
   @Test
+  public void testWriteAdditionalMetadata() throws RDFParseException, RDFHandlerException, IOException {
+  	String testTD = PREFIXES +
+  	    "@prefix eve: <http://w3id.org/eve#> .\n" +
+  	    "<http://example.org/lamp123> a td:Thing, saref:LightSwitch;\n" + 
+  	    "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" + 
+  	    "    dct:title \"My Lamp Thing\" ;\n" +
+  	    "    eve:hasManual [ a eve:Manual;\n" +
+  	    "        dct:title \"My Lamp Manual\";\n" +
+  	    "        eve:hasUsageProtocol [ a eve:UsageProtocol;\n" +
+  	    "            dct:title \"Party Light\";\n" +
+  	    "            eve:hasLanguage <http://jason.sourceforge.net/wp/description/>\n" +
+  	    "        ]\n" +
+  	    "    ].\n" ;
+  	    
+  	ValueFactory rdf = SimpleValueFactory.getInstance();
+  	Model metadata = new LinkedHashModel();
+  	
+  	final String NS = "http://w3id.org/eve#";
+  	metadata.setNamespace("eve", NS);
+  	  	
+    BNode manualId = rdf.createBNode();
+  	BNode protocolId = rdf.createBNode();
+  	metadata.add(rdf.createIRI("http://example.org/lamp123"), rdf.createIRI(NS,"hasManual"), manualId);
+  	metadata.add(manualId, RDF.TYPE, rdf.createIRI(NS, "Manual"));
+  	metadata.add(manualId, DCTERMS.TITLE, rdf.createLiteral("My Lamp Manual"));
+  	  	
+  	ThingDescription td = (new ThingDescription.Builder("My Lamp Thing"))
+  	    .addThingURI("http://example.org/lamp123")
+  	    .addSemanticType("https://w3id.org/saref#LightSwitch")
+  	    .addStatement(protocolId, RDF.TYPE, rdf.createIRI(NS, "UsageProtocol"))
+  	    .addStatement(protocolId, DCTERMS.TITLE, rdf.createLiteral("Party Light"))
+  	    .addGraph(metadata)
+  	    .addGraph(new ModelBuilder()
+  	    				.add(manualId, rdf.createIRI(NS, "hasUsageProtocol"), protocolId)
+  	    				.build())  	    
+  	    .addStatement(protocolId, rdf.createIRI(NS,"hasLanguage"), rdf.createIRI("http://jason.sourceforge.net/wp/description/"))
+  	    .build();
+        
+        assertIsomorphicGraphs(testTD, td);
+      
+  }
+  
+  @Test
   public void testWriteReadmeExample() throws RDFParseException, RDFHandlerException, IOException {
     String testTD = PREFIXES +
         "<http://example.org/lamp123> a td:Thing, saref:LightSwitch;\n" + 
@@ -324,6 +375,10 @@ public class TDGraphWriterTest {
     
     Model tdModel = ReadWriteTestUtils.readModelFromString(RDFFormat.TURTLE, description, 
         IO_BASE_IRI);
+    
+    System.out.println(expectedModel);
+    System.out.println("\n");
+    System.out.println(tdModel);
     
     assertTrue(Models.isomorphic(expectedModel, tdModel));
     


### PR DESCRIPTION
De-serialization of enumeration in SchemaGraphReader:
- Introduced readDataSchemaMetadata() in symmetry to SchemaGraphWriter.addDataSchemaMetadata().

Serialization of additional metadata (see ThingDescription and TDGraphWriter):
- Support for writing individual, multiple rdf4j Model graphs to TDs
- Support for passing arguments for rdf4j [simple triples](https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/model/impl/SimpleTriple.html) to TDs 
- The namespaces of the Model graphs are added to the namespaces of the TD
- E.g.:
```
Model metadataGraph = new LinkedHashModel();
metadataGraph.setNamespace("eve", "http://w3id.org/eve#");
metadataGraph.add(subject0, predicate0, object0);

ThingDescription td = (new ThingDescription.Builder("My Thing"))
    .addThingURI("http://example.org/thing123")
    .addSemanticType("https://w3id.org/saref#LightSwitch")
    .addTriple(subject1, predicate1, object1)
    .addGraph(metadataGraph)
    .addGraph(new ModelBuilder()
        .add(subject2, predicate2, object2)
        .build())          
     .addTriple(subject3, predicate3, object3)
     .build();

```
Closes #10
