### PR TITLE
Add td:name to affordances (mandatory in the JSON serialization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library is a work-in-progress. What you can do with the current version:
 - use property and action affordances with the data schemas defined by the [W3C Recommendation](https://www.w3.org/TR/wot-thing-description/#sec-data-schema-vocabulary-definition)
     - JSON Schema keywords are mapped to IRIs using the [JSON Schema in RDF vocabulary](https://www.w3.org/2019/wot/json-schema)
     - not all terms (and not all default values) are currently supported
-- use composite data schemas (e.g., arrays of nested objects with semantic annotations) 
+- use composite data schemas (e.g., arrays of nested objects with semantic annotations)
 
 Coming soon:
 - an HTTP client able to compose HTTP requests based on TDs
@@ -24,7 +24,7 @@ Coming soon:
 
 ## Reading TDs
 
-We can parse a TD from a string like so: 
+We can parse a TD from a string like so:
 
 ```java
 ThingDescription td = TDGraphReader.readFromString(description);
@@ -54,6 +54,7 @@ The above code snippet creates a `ThingDescription` for a lamp with the title `M
 
 ```java
 ActionAffordance toggle = new ActionAffordance.Builder(toggleForm)
+    .addName("toggle")
     .addTitle("Toggle")
     .addSemanticType("https://w3id.org/saref#ToggleCommand")
     .addInputSchema(new ObjectSchema.Builder()
@@ -73,7 +74,7 @@ The `toggle` action is exposed via a [Form](https://www.w3.org/TR/wot-thing-desc
 Form toggleForm = new Form("PUT", "http://mylamp.example.org/toggle");
 ```
 
-We can serialize our TD in Turtle like so (support for other formats is to be added): 
+We can serialize our TD in Turtle like so (support for other formats is to be added):
 
 ```java
 String description = new TDGraphWriter(td)
@@ -103,6 +104,7 @@ The generated TD is:
   dct:title "My Lamp Thing";
   td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];
   td:hasActionAffordance [ a td:ActionAffordance, saref:ToggleCommand;
+      td:name "toggle" ;
       dct:title "Toggle";
       td:hasForm [
           htv:methodName "PUT";
@@ -119,5 +121,5 @@ The generated TD is:
     ].
 ```
 
-In the above listing, notice the `TDGraphWriter` added for us a number of default values specified by the W3C WoT TD recommendation (e.g., `application/json` for our form's content type). 
+In the above listing, notice the `TDGraphWriter` added for us a number of default values specified by the W3C WoT TD recommendation (e.g., `application/json` for our form's content type).
 

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
@@ -17,32 +17,32 @@ import ch.unisg.ics.interactions.wot.td.security.SecurityScheme;
  * ThingDescription is immutable (hence the builder pattern)
  * can be extended
  * fields follow the W3C WoT spec: https://www.w3.org/TR/wot-thing-description/#thing
- * 
+ *
  * @author Andrei Ciortea
  *
  */
 public class ThingDescription {
   private final String title;
   private final List<SecurityScheme> security;
-  
+
   private final Optional<String> uri;
   private final Set<String> types;
   private final Optional<String> baseURI;
-  
+
   private final List<PropertyAffordance> properties;
   private final List<ActionAffordance> actions;
-  
+
   public enum TDFormat {
     RDF_TURTLE,
     RDF_JSONLD
   };
-  
-  protected ThingDescription(String title, List<SecurityScheme> security, Optional<String> uri, 
-      Set<String> types, Optional<String> baseURI, List<PropertyAffordance> properties, 
+
+  protected ThingDescription(String title, List<SecurityScheme> security, Optional<String> uri,
+      Set<String> types, Optional<String> baseURI, List<PropertyAffordance> properties,
       List<ActionAffordance> actions) {
-    
+
     this.title = title;
-    
+
     if (security.isEmpty()) {
       security.add(new NoSecurityScheme());
     }
@@ -51,152 +51,172 @@ public class ThingDescription {
     this.uri = uri;
     this.types = types;
     this.baseURI = baseURI;
-    
+
     this.properties = properties;
     this.actions = actions;
   }
-  
+
   public String getTitle() {
     return title;
   }
-  
+
   public List<SecurityScheme> getSecurity() {
     return security;
   }
-  
+
   public Optional<String> getThingURI() {
     return uri;
   }
-  
+
   public Set<String> getSemanticTypes() {
     return types;
   }
-  
+
   public Optional<String> getBaseURI() {
     return baseURI;
   }
-  
+
   public Set<String> getSupportedActionTypes() {
     Set<String> supportedActionTypes = new HashSet<String>();
-    
+
     for (ActionAffordance action : actions) {
       supportedActionTypes.addAll(action.getSemanticTypes());
     }
-    
+
     return supportedActionTypes;
   }
-  
+
+  public Optional<PropertyAffordance> getProperty(String name) {
+    for (PropertyAffordance property : properties) {
+      if (property.getName().equals(name)) {
+        return Optional.of(property);
+      }
+    }
+
+    return Optional.empty();
+  }
+
   public List<PropertyAffordance> getPropertiesByOperationType(String operationType) {
     return properties.stream().filter(property -> property.hasFormWithOperationType(operationType))
         .collect(Collectors.toList());
   }
-  
+
   public Optional<PropertyAffordance> getFirstPropertyBySemanticType(String propertyType) {
     for (PropertyAffordance property : properties) {
       if (property.getSemanticTypes().contains(propertyType)) {
         return Optional.of(property);
       }
     }
-    
+
     return Optional.empty();
   }
-  
+
+  public Optional<ActionAffordance> getAction(String name) {
+    for (ActionAffordance action : actions) {
+      if (action.getName().equals(name)) {
+        return Optional.of(action);
+      }
+    }
+
+    return Optional.empty();
+  }
+
   public List<ActionAffordance> getActionsByOperationType(String operationType) {
     return actions.stream().filter(action -> action.hasFormWithOperationType(operationType))
         .collect(Collectors.toList());
   }
-  
+
   public Optional<ActionAffordance> getFirstActionBySemanticType(String actionType) {
     for (ActionAffordance action : actions) {
       if (action.getSemanticTypes().contains(actionType)) {
         return Optional.of(action);
       }
     }
-    
+
     return Optional.empty();
   }
-  
+
   public List<PropertyAffordance> getProperties() {
     return this.properties;
   }
-  
+
   public List<ActionAffordance> getActions() {
     return this.actions;
   }
-  
+
   public static class Builder {
     private final String title;
     private final List<SecurityScheme> security;
-    
+
     private Optional<String> uri;
     private Optional<String> baseURI;
     private final Set<String> types;
-    
+
     private final List<PropertyAffordance> properties;
     private final List<ActionAffordance> actions;
-    
+
     public Builder(String title) {
       this.title = title;
       this.security = new ArrayList<SecurityScheme>();
-      
+
       this.uri = Optional.empty();
       this.baseURI = Optional.empty();
       this.types= new HashSet<String>();
-      
+
       this.properties = new ArrayList<PropertyAffordance>();
       this.actions = new ArrayList<ActionAffordance>();
     }
-    
+
     public Builder addSecurityScheme(SecurityScheme security) {
       this.security.add(security);
       return this;
     }
-    
+
     public Builder addSecuritySchemes(List<SecurityScheme> security) {
       this.security.addAll(security);
       return this;
     }
-    
+
     public Builder addThingURI(String uri) {
       this.uri = Optional.of(uri);
       return this;
     }
-    
+
     public Builder addBaseURI(String baseURI) {
       this.baseURI = Optional.of(baseURI);
       return this;
     }
-    
+
     public Builder addSemanticType(String type) {
       this.types.add(type);
       return this;
     }
-    
+
     public Builder addSemanticTypes(Set<String> thingTypes) {
       this.types.addAll(thingTypes);
       return this;
     }
-    
+
     public Builder addProperty(PropertyAffordance property) {
       this.properties.add(property);
       return this;
     }
-    
+
     public Builder addProperties(List<PropertyAffordance> properties) {
       this.properties.addAll(properties);
       return this;
     }
-    
+
     public Builder addAction(ActionAffordance action) {
       this.actions.add(action);
       return this;
     }
-    
+
     public Builder addActions(List<ActionAffordance> actions) {
       this.actions.addAll(actions);
       return this;
     }
-    
+
     public ThingDescription build() {
       return new ThingDescription(title, security, uri, types, baseURI, properties, actions);
     }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/ActionAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/ActionAffordance.java
@@ -10,72 +10,72 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 
 /**
  * TODO: add javadoc
- * 
+ *
  * @author Andrei Ciortea
  *
  */
 public class ActionAffordance extends InteractionAffordance {
   final private Optional<DataSchema> input;
   final private Optional<DataSchema> output;
-  
+
   // TODO: add safe, idempotent
-  
-  private ActionAffordance(Optional<String> title, List<String> types, List<Form> forms, 
+
+  private ActionAffordance(String name, Optional<String> title, List<String> types, List<Form> forms,
       Optional<DataSchema> input, Optional<DataSchema> output) {
-    super(title, types, forms);
+    super(name, title, types, forms);
     this.input = input;
     this.output = output;
   }
-  
+
   public Optional<Form> getFirstForm() {
     return getFirstFormForOperationType(TD.invokeAction);
   }
-  
+
   public Optional<DataSchema> getInputSchema() {
     return input;
   }
-  
+
   public Optional<DataSchema> getOutputSchema() {
     return output;
   }
-  
-  public static class Builder 
+
+  public static class Builder
       extends InteractionAffordance.Builder<ActionAffordance, ActionAffordance.Builder> {
-    
+
     private Optional<DataSchema> inputSchema;
     private Optional<DataSchema> outputSchema;
-    
+
     public Builder(List<Form> forms) {
       super(forms);
-      
+
       for (Form form : this.forms) {
         form.addOperationType(TD.invokeAction);
-        
+
         if (!form.getMethodName().isPresent()) {
           form.setMethodName("POST");
         }
       }
-      
+
       this.inputSchema = Optional.empty();
       this.outputSchema = Optional.empty();
     }
-    
+
     public Builder(Form form) {
       this(new ArrayList<Form>(Arrays.asList(form)));
     }
-    
+
     public Builder addInputSchema(DataSchema inputSchema) {
       this.inputSchema = Optional.of(inputSchema);
       return this;
     }
-    
+
     public Builder addOutputSchema(DataSchema outputSchema) {
       this.outputSchema = Optional.of(outputSchema);
       return this;
     }
-    
+
     public ActionAffordance build() {
-      return new ActionAffordance(this.title, this.types, this.forms, inputSchema, outputSchema);
+      return new ActionAffordance(this.name, this.title, this.types, this.forms, inputSchema, outputSchema);
     }
   }
 }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
@@ -1,14 +1,11 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * TODO: add javadoc
- * 
+ *
  * @author Andrei Ciortea
  *
  */
@@ -16,115 +13,136 @@ public class InteractionAffordance {
   public static final String PROPERTY = "property";
   public static final String EVENT = "event";
   public static final String ACTION = "action";
-  
+
+  protected String name;
   protected Optional<String> title;
   protected List<String> types;
   protected List<Form> forms;
-  
-  protected InteractionAffordance(Optional<String> title, List<String> types, List<Form> forms) {
+
+  protected InteractionAffordance(String name, Optional<String> title, List<String> types, List<Form> forms) {
+    this.name = name;
     this.title = title;
     this.types = types;
     this.forms = forms;
   }
-  
+
+  public String getName() {
+    return name;
+  }
+
   public Optional<String> getTitle() {
     return title;
   }
-  
+
   public List<String> getSemanticTypes() {
     return types;
   }
-  
+
   public List<Form> getForms() {
     return forms;
   }
-  
+
   public boolean hasFormWithOperationType(String operationType) {
     return !forms.stream().filter(form -> form.hasOperationType(operationType))
         .collect(Collectors.toList()).isEmpty();
   }
-  
+
   public Optional<Form> getFirstFormForOperationType(String operationType) {
     if (hasFormWithOperationType(operationType)) {
       Form firstForm = forms.stream().filter(form -> form.hasOperationType(operationType))
           .collect(Collectors.toList()).get(0);
-      
+
       return Optional.of(firstForm);
     }
-    
+
     return Optional.empty();
   }
-  
+
   public boolean hasSemanticType(String type) {
     return this.types.contains(type);
   }
-  
+
   public boolean hasOneSemanticType(List<String> types) {
     for (String type : types) {
       if (this.types.contains(type)) {
         return true;
       }
     }
-    
+
     return false;
   }
-  
+
   public boolean hasAllSemanticTypes(List<String> types) {
     for (String type : types) {
       if (!this.types.contains(type)) {
         return false;
       }
     }
-    
+
     return true;
   }
-  
+
   /** Abstract builder for interaction affordances. */
   public static abstract class Builder<T extends InteractionAffordance, S extends Builder<T,S>> {
+    protected String name;
     protected Optional<String> title;
     protected List<String> types;
     protected List<Form> forms;
-    
+
     protected Builder(List<Form> forms) {
+      this.name = generateName();
       this.title = Optional.empty();
       this.types = new ArrayList<String>();
       this.forms = forms;
     }
-    
+
     protected Builder(Form form) {
       this(new ArrayList<Form>(Arrays.asList(form)));
     }
-    
+
+    protected String generateName() {
+      UUID uuid = UUID.randomUUID();
+      long lsb = uuid.getLeastSignificantBits();
+      long msb = uuid.getMostSignificantBits();
+
+      return "_" + Long.toHexString(lsb) + Long.toHexString(msb);
+    }
+
+    public S addName(String name) {
+      this.name = name;
+      return (S) this;
+    }
+
     @SuppressWarnings("unchecked")
     public S addTitle(String title) {
       this.title = Optional.of(title);
       return (S) this;
     }
-    
+
     @SuppressWarnings("unchecked")
     public S addSemanticType(String type) {
       this.types.add(type);
       return (S) this;
     }
-    
+
     @SuppressWarnings("unchecked")
     public S addSemanticTypes(List<String> types) {
       this.types.addAll(types);
       return (S) this;
     }
-    
+
     @SuppressWarnings("unchecked")
     public S addForm(Form form) {
       this.forms.add(form);
       return (S) this;
     }
-    
+
     @SuppressWarnings("unchecked")
     public S addForms(List<Form> forms) {
       this.forms.addAll(forms);
       return (S) this;
     }
-    
+
     public abstract T build();
   }
 }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
@@ -100,7 +100,8 @@ public class InteractionAffordance {
       this(new ArrayList<Form>(Arrays.asList(form)));
     }
 
-    protected String generateName() {
+    private String generateName() {
+      // FIXME specialized builders should be able to override name generation
       UUID uuid = UUID.randomUUID();
       long lsb = uuid.getLeastSignificantBits();
       long msb = uuid.getMostSignificantBits();

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/PropertyAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/PropertyAffordance.java
@@ -11,52 +11,52 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 public class PropertyAffordance extends InteractionAffordance {
   private final DataSchema schema;
   private final boolean observable;
-  
-  private PropertyAffordance(DataSchema schema, boolean observable, Optional<String> title, 
+
+  private PropertyAffordance(String name, DataSchema schema, boolean observable, Optional<String> title,
       List<String> types, List<Form> forms) {
-    super(title, types, forms);
+    super(name, title, types, forms);
     this.schema = schema;
     this.observable = observable;
   }
-  
+
   public DataSchema getDataSchema() {
     return schema;
   }
-  
+
   public boolean isObservable() {
     return observable;
   }
-  
-  public static class Builder 
+
+  public static class Builder
       extends InteractionAffordance.Builder<PropertyAffordance, PropertyAffordance.Builder> {
 
     private final DataSchema schema;
     private boolean observable;
-    
+
     public Builder(DataSchema schema, List<Form> forms) {
       super(forms);
-      
+
       for (Form form : this.forms) {
         form.addOperationType(TD.readProperty);
         form.addOperationType(TD.writeProperty);
       }
-      
+
       this.schema = schema;
       this.observable = false;
     }
-    
+
     public Builder(DataSchema schema, Form form) {
       this(schema, new ArrayList<Form>(Arrays.asList(form)));
     }
-    
+
     public Builder addObserve() {
       this.observable = true;
       return this;
     }
-    
+
     @Override
     public PropertyAffordance build() {
-      return new PropertyAffordance(schema, observable, title, types, forms);
+      return new PropertyAffordance(name, schema, observable, title, types, forms);
     }
   }
 }

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/ActionAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/ActionAffordanceTest.java
@@ -13,10 +13,10 @@ import org.junit.Test;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 
 public class ActionAffordanceTest {
-  
+
   private ActionAffordance testAction;
   private Form form;
-  
+
   @Before
   public void init() {
     form = new Form.Builder("http://example.org/action").build();
@@ -29,53 +29,55 @@ public class ActionAffordanceTest {
     assertEquals(1, forms.size());
     assertEquals(form, forms.get(0));
   }
-  
+
   @Test
   public void testMultipleForms() {
     Form form1 = new Form.Builder("http://example.org")
         .setMethodName("GET")
         .setContentType("application/json")
         .build();
-    
+
     Form form2 = new Form.Builder("http://example.org")
         .setMethodName("POST")
         .setContentType("application/json")
         .build();
-    
+
     Form form3 = new Form.Builder("http://example.org")
         .setMethodName("PUT")
         .setContentType("application/json")
         .build();
-    
+
     List<Form> formList = new ArrayList<Form>(Arrays.asList(form1, form2, form3));
-    
+
     ActionAffordance action = (new ActionAffordance.Builder(formList)).build();
     List<Form> forms = action.getForms();
-    
+
     assertEquals(3, forms.size());
     assertEquals(form1, forms.get(0));
     assertEquals(form2, forms.get(1));
     assertEquals(form3, forms.get(2));
   }
-  
+
   @Test
   public void testDefaultValues() {
     String invokeAction = TD.invokeAction;
     assertTrue(testAction.hasFormWithOperationType(invokeAction));
     assertEquals("POST", testAction.getForms().get(0).getMethodName(invokeAction).get());
   }
-  
+
   @Test
   public void testFullOptionAction() {
     Form form = new Form.Builder("http://example.org").setMethodName("GET").build();
-    
+
     ActionAffordance action = (new ActionAffordance.Builder(form))
+        .addName("turnOn")
         .addTitle("Turn on")
         .addSemanticType("iot:TurnOn")
         // TODO: add schema as well
         //.addInputSchema(inputSchema)
         .build();
-    
+
+    assertEquals("turnOn", action.getName());
     assertEquals("Turn on", action.getTitle().get());
     assertEquals(1, action.getSemanticTypes().size());
     assertEquals("iot:TurnOn", action.getSemanticTypes().get(0));

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
@@ -14,72 +14,72 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 public class InteractionAffordanceTest {
   private static final String prefix = "http://example.org";
   private InteractionAffordance test_affordance;
-  
+
   @Before
   public void init() {
     Form form1 = new Form.Builder("http://example.org/property1")
         .addOperationType(TD.readProperty)
         .build();
-    
+
     Form form2 = new Form.Builder("http://example.org/property2")
         .addOperationType(TD.writeProperty)
         .build();
-    
-    test_affordance = new InteractionAffordance(Optional.of("My Affordance"), 
+
+    test_affordance = new InteractionAffordance("myAffordance", Optional.of("My Affordance"),
         Arrays.asList(prefix + "Type1", prefix + "Type2"), Arrays.asList(form1, form2));
   }
-  
+
   @Test
   public void testHasFormForOperationType() {
     assertTrue(test_affordance.hasFormWithOperationType(TD.readProperty));
     assertTrue(test_affordance.hasFormWithOperationType(TD.writeProperty));
   }
-  
+
   @Test
   public void testNoFormByOperationType() {
     assertFalse(test_affordance.hasFormWithOperationType("bla"));
   }
-  
+
   @Test
   public void testHasSemanticType() {
     assertTrue(test_affordance.hasSemanticType(prefix + "Type1"));
   }
-  
+
   @Test
   public void testHasNotSemanticType() {
     assertFalse(test_affordance.hasSemanticType(prefix + "Type0"));
   }
-  
+
   @Test
   public void testHasOneSemanticType() {
-    assertTrue(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type0", 
+    assertTrue(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type0",
         prefix + "Type1")));
   }
-  
+
   @Test
   public void testHasNotOneSemanticType() {
-    assertFalse(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type3", 
+    assertFalse(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type3",
         prefix + "Type4")));
   }
-  
+
   @Test
   public void testHasAllSemanticTypes() {
-    assertTrue(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1", 
+    assertTrue(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1",
         prefix + "Type2")));
   }
-  
+
   @Test
   public void testHasNotAllSemanticTypes() {
-    assertFalse(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1", 
+    assertFalse(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1",
         prefix + "Type2", prefix + "Type3")));
   }
-  
+
   @Test
   public void testGetFirstFormForOperationType() {
     assertTrue(test_affordance.getFirstFormForOperationType(TD.readProperty)
         .isPresent());
   }
-  
+
   @Test
   public void testNoFirstFormForOperationType() {
     assertFalse(test_affordance.getFirstFormForOperationType(TD.invokeAction)

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/PropertyAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/PropertyAffordanceTest.java
@@ -1,8 +1,5 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -10,37 +7,41 @@ import ch.unisg.ics.interactions.wot.td.schemas.DataSchema;
 import ch.unisg.ics.interactions.wot.td.schemas.NumberSchema;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 
+import static org.junit.Assert.*;
+
 public class PropertyAffordanceTest {
 
   private PropertyAffordance testProperty;
-  
+
   @Before
   public void init() {
     DataSchema schema = new NumberSchema.Builder().build();
     Form form = new Form.Builder("http://example.org/action1")
         .build();
-    
+
     testProperty = new PropertyAffordance.Builder(schema, form)
+        .addName("myProperty")
         .addTitle("My Property")
         .addSemanticType("sem_type")
         .addObserve()
         .build();
   }
-  
+
   @Test
   public void testProperty() {
+    assertEquals("myProperty", testProperty.getName());
     assertEquals("My Property", testProperty.getTitle().get());
     assertTrue(testProperty.getSemanticTypes().contains("sem_type"));
     assertEquals(DataSchema.NUMBER, testProperty.getDataSchema().getDatatype());
     assertEquals(1, testProperty.getForms().size());
     assertTrue(testProperty.isObservable());
   }
-  
+
   @Test
   public void testDefaultOperationTypes() {
     assertTrue(testProperty.hasFormWithOperationType(TD.readProperty));
     assertTrue(testProperty.hasFormWithOperationType(TD.writeProperty));
-    
+
     Form form = testProperty.getForms().get(0);
     assertEquals("GET", form.getMethodName(TD.readProperty).get());
     assertEquals("PUT", form.getMethodName(TD.writeProperty).get());

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReaderTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReaderTest.java
@@ -27,7 +27,7 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 import ch.unisg.ics.interactions.wot.td.vocabularies.WoTSec;
 
 public class TDGraphReaderTest {
-  
+
   private static final String TEST_SIMPLE_TD =
       "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
       "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
@@ -36,143 +36,148 @@ public class TDGraphReaderTest {
       "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
       "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
       "\n" +
-      "<http://example.org/#thing> a td:Thing ;\n" + 
+      "<http://example.org/#thing> a td:Thing ;\n" +
       "    dct:title \"My Thing\" ;\n" +
       "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
       "    td:hasBase <http://example.org/> ;\n" +
-      "    td:hasPropertyAffordance [\n" + 
+      "    td:hasPropertyAffordance [\n" +
       "        a td:PropertyAffordance, js:NumberSchema ;\n" +
+        "      td:name \"myProperty\" ;\n" +
       "        dct:title \"My Property\" ;\n" +
       "        td:isObservable true ;\n" +
-      "        td:hasForm [\n" + 
-      "            htv:methodName \"PUT\" ;\n" + 
-      "            hctl:hasTarget <http://example.org/property> ;\n" + 
-      "            hctl:forContentType \"application/json\";\n" + 
-      "            hctl:hasOperationType td:writeProperty;\n" + 
-      "        ] ;\n" + 
-      "        td:hasForm [\n" + 
-      "            htv:methodName \"GET\" ;\n" + 
-      "            hctl:hasTarget <http://example.org/property> ;\n" + 
-      "            hctl:forContentType \"application/json\";\n" + 
-      "            hctl:hasOperationType td:readProperty;\n" + 
-      "        ] ;\n" + 
-      "    ] ;\n" + 
-      "    td:hasActionAffordance [\n" + 
-      "        a td:ActionAffordance ;\n" + 
-      "        dct:title \"My Action\" ;\n" + 
-      "        td:hasForm [\n" + 
-      "            htv:methodName \"PUT\" ;\n" + 
-      "            hctl:hasTarget <http://example.org/action> ;\n" + 
-      "            hctl:forContentType \"application/json\";\n" + 
-      "            hctl:hasOperationType td:invokeAction;\n" + 
-      "        ] ;\n" + 
-      "        td:hasInputSchema [\n" + 
-      "            a js:ObjectSchema ;\n" + 
-      "            js:properties [\n" + 
+      "        td:hasForm [\n" +
+      "            htv:methodName \"PUT\" ;\n" +
+      "            hctl:hasTarget <http://example.org/property> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:writeProperty;\n" +
+      "        ] ;\n" +
+      "        td:hasForm [\n" +
+      "            htv:methodName \"GET\" ;\n" +
+      "            hctl:hasTarget <http://example.org/property> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:readProperty;\n" +
+      "        ] ;\n" +
+      "    ] ;\n" +
+      "    td:hasActionAffordance [\n" +
+      "        a td:ActionAffordance ;\n" +
+        "      td:name \"myAction\" ;\n" +
+      "        dct:title \"My Action\" ;\n" +
+      "        td:hasForm [\n" +
+      "            htv:methodName \"PUT\" ;\n" +
+      "            hctl:hasTarget <http://example.org/action> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:invokeAction;\n" +
+      "        ] ;\n" +
+      "        td:hasInputSchema [\n" +
+      "            a js:ObjectSchema ;\n" +
+      "            js:properties [\n" +
       "                a js:NumberSchema ;\n" +
       "                js:propertyName \"number_value\";\n" +
-      "                js:maximum 100.05 ;\n" + 
+      "                js:maximum 100.05 ;\n" +
       "                js:minimum -100.05 ;\n" +
       "            ] ;\n" +
       "            js:required \"number_value\" ;\n" +
-      "        ] ;\n" + 
-      "        td:hasOutputSchema [\n" + 
-      "            a js:ObjectSchema ;\n" + 
-      "            js:properties [\n" + 
+      "        ] ;\n" +
+      "        td:hasOutputSchema [\n" +
+      "            a js:ObjectSchema ;\n" +
+      "            js:properties [\n" +
       "                a js:BooleanSchema ;\n" +
       "                js:propertyName \"boolean_value\";\n" +
       "            ] ;\n" +
       "            js:required \"boolean_value\" ;\n" +
-      "        ]\n" + 
+      "        ]\n" +
       "    ] ." ;
-  
-  private static final String TEST_SIMPLE_TD_JSONLD = "[ {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx111\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/security#NoSecurityScheme\" ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx112\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/td#ActionAffordance\" ],\n" + 
-      "  \"http://purl.org/dc/terms/title\" : [ {\n" + 
-      "    \"@value\" : \"My Action\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasForm\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx113\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasInputSchema\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx114\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasOutputSchema\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx116\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx113\",\n" + 
-      "  \"http://www.w3.org/2011/http#methodName\" : [ {\n" + 
-      "    \"@value\" : \"PUT\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/hypermedia#forContentType\" : [ {\n" + 
-      "    \"@value\" : \"application/json\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/hypermedia#hasOperationType\" : [ {\n" + 
-      "    \"@id\" : \"https://www.w3.org/2019/wot/td#invokeAction\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/hypermedia#hasTarget\" : [ {\n" + 
-      "    \"@id\" : \"http://example.org/action\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx114\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#ObjectSchema\" ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#properties\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx115\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#required\" : [ {\n" + 
-      "    \"@value\" : \"number_value\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx115\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#NumberSchema\" ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#maximum\" : [ {\n" + 
-      "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#decimal\",\n" + 
-      "    \"@value\" : \"100.05\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#minimum\" : [ {\n" + 
-      "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#decimal\",\n" + 
-      "    \"@value\" : \"-100.05\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#propertyName\" : [ {\n" + 
-      "    \"@value\" : \"number_value\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx116\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#ObjectSchema\" ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#properties\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx117\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#required\" : [ {\n" + 
-      "    \"@value\" : \"boolean_value\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx117\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#BooleanSchema\" ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#propertyName\" : [ {\n" + 
-      "    \"@value\" : \"boolean_value\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"http://example.org/#thing\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/td#Thing\" ],\n" + 
-      "  \"http://purl.org/dc/terms/title\" : [ {\n" + 
-      "    \"@value\" : \"My Thing\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasActionAffordance\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx112\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasBase\" : [ {\n" + 
-      "    \"@id\" : \"http://example.org/\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasSecurityConfiguration\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx111\"\n" + 
-      "  } ]\n" + 
+
+  private static final String TEST_SIMPLE_TD_JSONLD = "[ {\n" +
+      "  \"@id\" : \"_:node1ea75dfphx111\",\n" +
+      "  \"@type\" : [ \"https://www.w3.org/2019/wot/security#NoSecurityScheme\" ]\n" +
+      "}, {\n" +
+      "  \"@id\" : \"_:node1ea75dfphx112\",\n" +
+      "  \"@type\" : [ \"https://www.w3.org/2019/wot/td#ActionAffordance\" ],\n" +
+      "  \"https://www.w3.org/2019/wot/td#name\" : [ {\n" +
+      "    \"@value\" : \"myAction\"\n" +
+      "  } ],\n" +
+      "  \"http://purl.org/dc/terms/title\" : [ {\n" +
+      "    \"@value\" : \"My Action\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/td#hasForm\" : [ {\n" +
+      "    \"@id\" : \"_:node1ea75dfphx113\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/td#hasInputSchema\" : [ {\n" +
+      "    \"@id\" : \"_:node1ea75dfphx114\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/td#hasOutputSchema\" : [ {\n" +
+      "    \"@id\" : \"_:node1ea75dfphx116\"\n" +
+      "  } ]\n" +
+      "}, {\n" +
+      "  \"@id\" : \"_:node1ea75dfphx113\",\n" +
+      "  \"http://www.w3.org/2011/http#methodName\" : [ {\n" +
+      "    \"@value\" : \"PUT\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/hypermedia#forContentType\" : [ {\n" +
+      "    \"@value\" : \"application/json\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/hypermedia#hasOperationType\" : [ {\n" +
+      "    \"@id\" : \"https://www.w3.org/2019/wot/td#invokeAction\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/hypermedia#hasTarget\" : [ {\n" +
+      "    \"@id\" : \"http://example.org/action\"\n" +
+      "  } ]\n" +
+      "}, {\n" +
+      "  \"@id\" : \"_:node1ea75dfphx114\",\n" +
+      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#ObjectSchema\" ],\n" +
+      "  \"https://www.w3.org/2019/wot/json-schema#properties\" : [ {\n" +
+      "    \"@id\" : \"_:node1ea75dfphx115\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/json-schema#required\" : [ {\n" +
+      "    \"@value\" : \"number_value\"\n" +
+      "  } ]\n" +
+      "}, {\n" +
+      "  \"@id\" : \"_:node1ea75dfphx115\",\n" +
+      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#NumberSchema\" ],\n" +
+      "  \"https://www.w3.org/2019/wot/json-schema#maximum\" : [ {\n" +
+      "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#decimal\",\n" +
+      "    \"@value\" : \"100.05\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/json-schema#minimum\" : [ {\n" +
+      "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#decimal\",\n" +
+      "    \"@value\" : \"-100.05\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/json-schema#propertyName\" : [ {\n" +
+      "    \"@value\" : \"number_value\"\n" +
+      "  } ]\n" +
+      "}, {\n" +
+      "  \"@id\" : \"_:node1ea75dfphx116\",\n" +
+      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#ObjectSchema\" ],\n" +
+      "  \"https://www.w3.org/2019/wot/json-schema#properties\" : [ {\n" +
+      "    \"@id\" : \"_:node1ea75dfphx117\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/json-schema#required\" : [ {\n" +
+      "    \"@value\" : \"boolean_value\"\n" +
+      "  } ]\n" +
+      "}, {\n" +
+      "  \"@id\" : \"_:node1ea75dfphx117\",\n" +
+      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#BooleanSchema\" ],\n" +
+      "  \"https://www.w3.org/2019/wot/json-schema#propertyName\" : [ {\n" +
+      "    \"@value\" : \"boolean_value\"\n" +
+      "  } ]\n" +
+      "}, {\n" +
+      "  \"@id\" : \"http://example.org/#thing\",\n" +
+      "  \"@type\" : [ \"https://www.w3.org/2019/wot/td#Thing\" ],\n" +
+      "  \"http://purl.org/dc/terms/title\" : [ {\n" +
+      "    \"@value\" : \"My Thing\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/td#hasActionAffordance\" : [ {\n" +
+      "    \"@id\" : \"_:node1ea75dfphx112\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/td#hasBase\" : [ {\n" +
+      "    \"@id\" : \"http://example.org/\"\n" +
+      "  } ],\n" +
+      "  \"https://www.w3.org/2019/wot/td#hasSecurityConfiguration\" : [ {\n" +
+      "    \"@id\" : \"_:node1ea75dfphx111\"\n" +
+      "  } ]\n" +
       "} ]";
-  
+
   private static final String TEST_IO_HEAD =
       "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
       "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
@@ -181,54 +186,55 @@ public class TDGraphReaderTest {
       "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
       "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
       "\n" +
-      "<http://example.org/#thing> a td:Thing ;\n" + 
+      "<http://example.org/#thing> a td:Thing ;\n" +
       "    dct:title \"My Thing\" ;\n" +
       "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-      "    td:hasBase <http://example.org/> ;\n" + 
-      "    td:hasActionAffordance [\n" + 
-      "        a td:ActionAffordance ;\n" + 
-      "        dct:title \"My Action\" ;\n" + 
-      "        td:hasForm [\n" + 
-      "            htv:methodName \"PUT\" ;\n" + 
-      "            hctl:hasTarget <http://example.org/action> ;\n" + 
-      "            hctl:forContentType \"application/json\";\n" + 
-      "            hctl:hasOperationType td:invokeAction;\n" + 
+      "    td:hasBase <http://example.org/> ;\n" +
+      "    td:hasActionAffordance [\n" +
+      "        a td:ActionAffordance ;\n" +
+      "        td:name \"myAction\" ;\n" +
+      "        dct:title \"My Action\" ;\n" +
+      "        td:hasForm [\n" +
+      "            htv:methodName \"PUT\" ;\n" +
+      "            hctl:hasTarget <http://example.org/action> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:invokeAction;\n" +
       "        ] ;\n";
-      
+
   private static final String TEST_IO_TAIL = "    ] ." ;
-  
+
   @Test
   public void testReadTitle() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.JSONLD, TEST_SIMPLE_TD_JSONLD);
-    
+
     assertEquals("My Thing", reader.readThingTitle());
   }
-  
+
   @Test
   public void testReadThingTypes() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     assertEquals(1, reader.readThingTypes().size());
     assertTrue(reader.readThingTypes().contains(TD.Thing));
   }
-  
+
   @Test
   public void testReadBaseURI() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     assertEquals("http://example.org/", reader.readBaseURI().get());
   }
-  
+
   @Test
   public void testReadOneSecurityScheme() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     assertEquals(1, reader.readSecuritySchemes().size());
-    
-    assertTrue(reader.readSecuritySchemes().stream().anyMatch(scheme -> 
+
+    assertTrue(reader.readSecuritySchemes().stream().anyMatch(scheme ->
         scheme.getSchemaType().equals(WoTSec.NoSecurityScheme)));
   }
-  
+
   @Test
   public void testReadAPIKeySecurityScheme() {
     String testTD =
@@ -236,24 +242,24 @@ public class TDGraphReaderTest {
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ;\n" +
         "        wotsec:in \"header\" ;\n" +
         "        wotsec:name \"X-API-Key\" ;\n" +
         "  ] .";
-    
+
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, testTD);
-    
+
     assertEquals(1, reader.readSecuritySchemes().size());
-    
+
     SecurityScheme scheme = reader.readSecuritySchemes().iterator().next();
     assertTrue(scheme instanceof APIKeySecurityScheme);
     assertEquals(WoTSec.APIKeySecurityScheme, ((APIKeySecurityScheme) scheme).getSchemaType());
     assertEquals(TokenLocation.HEADER, ((APIKeySecurityScheme) scheme).getIn());
     assertEquals("X-API-Key", ((APIKeySecurityScheme) scheme).getName().get());
   }
-  
+
   @Test
   public void testAPIKeySecuritySchemeDefaultValues() {
     String testTD =
@@ -261,10 +267,10 @@ public class TDGraphReaderTest {
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ] .";
-    
+
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, testTD);
     assertEquals(1, reader.readSecuritySchemes().size());
     SecurityScheme scheme = reader.readSecuritySchemes().iterator().next();
@@ -272,7 +278,7 @@ public class TDGraphReaderTest {
     assertEquals(TokenLocation.QUERY, ((APIKeySecurityScheme) scheme).getIn());
     assertFalse(((APIKeySecurityScheme) scheme).getName().isPresent());
   }
-  
+
   @Test(expected = InvalidTDException.class)
   public void testAPIKeySecuritySchemeInvalidTokenLocation() {
     String testTD =
@@ -280,15 +286,15 @@ public class TDGraphReaderTest {
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ;\n" +
         "        wotsec:in \"bla\" ;\n" +
         "  ] .";
-    
+
     new TDGraphReader(RDFFormat.TURTLE, testTD).readSecuritySchemes();
   }
-  
+
   @Test
   public void testReadMultipleSecuritySchemes() {
     String testTD =
@@ -298,51 +304,53 @@ public class TDGraphReaderTest {
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ] ;\n" +
         "    td:hasBase <http://example.org/> .";
-    
+
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, testTD);
-    
+
     assertTrue(reader.readSecuritySchemes().stream().anyMatch(scheme -> scheme.getSchemaType()
         .equals(WoTSec.NoSecurityScheme)));
     assertTrue(reader.readSecuritySchemes().stream().anyMatch(scheme -> scheme.getSchemaType()
         .equals(WoTSec.APIKeySecurityScheme)));
   }
-  
+
   @Test
   public void testReadOneSimpleProperty() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     List<PropertyAffordance> properties = reader.readProperties();
     assertEquals(1, properties.size());
-    
+
     PropertyAffordance property = properties.get(0);
+    assertEquals("myProperty", property.getName());
     assertEquals("My Property", property.getTitle().get());
     assertTrue(property.isObservable());
     assertEquals(2, property.getSemanticTypes().size());
     assertEquals(2, property.getForms().size());
   }
-  
+
   @Test
   public void testReadOneSimpleAction() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     assertEquals(1, reader.readActions().size());
     ActionAffordance action = reader.readActions().get(0);
-    
+
+    assertEquals("myAction", action.getName());
     assertEquals("My Action", action.getTitle().get());
     assertEquals(1, action.getSemanticTypes().size());
     assertEquals(TD.ActionAffordance, action.getSemanticTypes().get(0));
-    
+
     assertEquals(1, action.getForms().size());
     Form form = action.getForms().get(0);
-    
+
     assertForm(form, "PUT", "http://example.org/action", "application/json", TD.invokeAction);
   }
-  
+
   @Test
   public void testReadMultipleSimpleActions() {
     String testTD =
@@ -353,125 +361,125 @@ public class TDGraphReaderTest {
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-        "    td:hasBase <http://example.org/> ;\n" + 
-        "    td:hasActionAffordance [\n" + 
-        "        a td:ActionAffordance ;\n" + 
-        "        dct:title \"First Action\" ;\n" + 
-        "        td:hasForm [\n" + 
-        "            htv:methodName \"PUT\" ;\n" + 
-        "            hctl:hasTarget <http://example.org/action1> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:invokeAction;\n" + 
-        "        ] ;\n" + 
-        "    ] ;\n" +
-        "    td:hasActionAffordance [\n" + 
-        "        a td:ActionAffordance ;\n" + 
-        "        dct:title \"Second Action\" ;\n" + 
-        "        td:hasForm [\n" + 
-        "            htv:methodName \"PUT\" ;\n" + 
-        "            hctl:hasTarget <http://example.org/action2> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:invokeAction;\n" + 
+        "    td:hasBase <http://example.org/> ;\n" +
+        "    td:hasActionAffordance [\n" +
+        "        a td:ActionAffordance ;\n" +
+        "        dct:title \"First Action\" ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/action1> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:invokeAction;\n" +
         "        ] ;\n" +
         "    ] ;\n" +
-        "    td:hasActionAffordance [\n" + 
-        "        a td:ActionAffordance ;\n" + 
-        "        dct:title \"Third Action\" ;\n" + 
-        "        td:hasForm [\n" + 
-        "            htv:methodName \"PUT\" ;\n" + 
-        "            hctl:hasTarget <http://example.org/action3> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:invokeAction;\n" + 
-        "        ] ;\n" + 
+        "    td:hasActionAffordance [\n" +
+        "        a td:ActionAffordance ;\n" +
+        "        dct:title \"Second Action\" ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/action2> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:invokeAction;\n" +
+        "        ] ;\n" +
+        "    ] ;\n" +
+        "    td:hasActionAffordance [\n" +
+        "        a td:ActionAffordance ;\n" +
+        "        dct:title \"Third Action\" ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/action3> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:invokeAction;\n" +
+        "        ] ;\n" +
         "    ] ." ;
-    
+
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, testTD);
-    
+
     assertEquals(3, reader.readActions().size());
-    
+
     List<String> actionTitles = reader.readActions().stream().map(action -> action.getTitle().get())
         .collect(Collectors.toList());
-    
+
     assertTrue(actionTitles.contains("First Action"));
     assertTrue(actionTitles.contains("Second Action"));
     assertTrue(actionTitles.contains("Third Action"));
   }
-  
+
   @Test
   public void testReadOneActionOneObjectInput() {
     String testSimpleObject =
-        "        td:hasInputSchema [\n" + 
-        "            a js:ObjectSchema ;\n" + 
-        "            js:properties [\n" + 
+        "        td:hasInputSchema [\n" +
+        "            a js:ObjectSchema ;\n" +
+        "            js:properties [\n" +
         "                a js:BooleanSchema ;\n" +
         "                js:propertyName \"boolean_value\";\n" +
         "            ] ;\n" +
-        "            js:properties [\n" + 
+        "            js:properties [\n" +
         "                a js:NumberSchema ;\n" +
         "                js:propertyName \"number_value\";\n" +
-        "                js:maximum 100.05 ;\n" + 
+        "                js:maximum 100.05 ;\n" +
         "                js:minimum -100.05 ;\n" +
         "            ] ;\n" +
-        "            js:properties [\n" + 
+        "            js:properties [\n" +
         "                a js:IntegerSchema ;\n" +
         "                js:propertyName \"integer_value\";\n" +
-        "                js:maximum 100 ;\n" + 
+        "                js:maximum 100 ;\n" +
         "                js:minimum -100 ;\n" +
         "            ] ;\n" +
-        "            js:properties [\n" + 
+        "            js:properties [\n" +
         "                a js:StringSchema ;\n" +
         "                js:propertyName \"string_value\";\n" +
         "            ] ;\n" +
-        "            js:properties [\n" + 
+        "            js:properties [\n" +
         "                a js:NullSchema ;\n" +
         "                js:propertyName \"null_value\";\n" +
         "            ] ;\n" +
         "            js:required \"integer_value\", \"number_value\" ;\n" +
         "        ]\n";
-    
-    TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_IO_HEAD + testSimpleObject 
+
+    TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_IO_HEAD + testSimpleObject
         + TEST_IO_TAIL);
-    
+
     ActionAffordance action = reader.readActions().get(0);
-    
+
     Optional<DataSchema> input = action.getInputSchema();
     assertTrue(input.isPresent());
     assertEquals(DataSchema.OBJECT, input.get().getDatatype());
-    
+
     ObjectSchema schema = (ObjectSchema) input.get();
     assertEquals(5, schema.getProperties().size());
-    
+
     DataSchema booleanProperty = schema.getProperties().get("boolean_value");
     assertEquals(DataSchema.BOOLEAN, booleanProperty.getDatatype());
-    
+
     DataSchema integerProperty = schema.getProperties().get("integer_value");
     assertEquals(DataSchema.INTEGER, integerProperty.getDatatype());
     assertEquals(-100, ((IntegerSchema) integerProperty).getMinimum().get().intValue());
     assertEquals(100, ((IntegerSchema) integerProperty).getMaximum().get().intValue());
-    
+
     DataSchema numberProperty = schema.getProperties().get("number_value");
     assertEquals(DataSchema.NUMBER, numberProperty.getDatatype());
     assertEquals(-100.05, ((NumberSchema) numberProperty).getMinimum().get().doubleValue(), 0.001);
     assertEquals(100.05, ((NumberSchema) numberProperty).getMaximum().get().doubleValue(), 0.001);
-    
+
     DataSchema stringProperty = schema.getProperties().get("string_value");
     assertEquals(DataSchema.STRING, stringProperty.getDatatype());
-    
+
     DataSchema nullProperty = schema.getProperties().get("null_value");
     assertEquals(DataSchema.NULL, nullProperty.getDatatype());
-    
+
     assertEquals(2, schema.getRequiredProperties().size());
     assertTrue(schema.getRequiredProperties().contains("integer_value"));
     assertTrue(schema.getRequiredProperties().contains("number_value"));
   }
-  
+
   @Test
   public void testReadSimpleFullTD() {
     ThingDescription td = TDGraphReader.readFromString(TDFormat.RDF_TURTLE, TEST_SIMPLE_TD);
-    
+
     // Check metadata
     assertEquals("My Thing", td.getTitle());
     assertEquals("http://example.org/#thing", td.getThingURI().get());
@@ -480,41 +488,42 @@ public class TDGraphReaderTest {
     assertTrue(td.getSecurity().stream().anyMatch(scheme -> scheme.getSchemaType()
         .equals(WoTSec.NoSecurityScheme)));
     assertEquals(1, td.getActions().size());
-    
+
     // Check action metadata
     ActionAffordance action = td.getActions().get(0);
+    assertEquals("myAction", action.getName());
     assertEquals("My Action", action.getTitle().get());
     assertEquals(1, action.getForms().size());
-    
+
     // Check action form
     Form form = action.getForms().get(0);
     assertForm(form, "PUT", "http://example.org/action", "application/json", TD.invokeAction);
-    
+
     // Check action input data schema
     ObjectSchema input = (ObjectSchema) action.getInputSchema().get();
     assertEquals(DataSchema.OBJECT, input.getDatatype());
     assertEquals(1, input.getProperties().size());
     assertEquals(1, input.getRequiredProperties().size());
-    
+
     assertEquals(DataSchema.NUMBER, input.getProperties().get("number_value").getDatatype());
     assertTrue(input.getRequiredProperties().contains("number_value"));
-    
+
     // Check action output data schema
     ObjectSchema output = (ObjectSchema) action.getOutputSchema().get();
     assertEquals(DataSchema.OBJECT, output.getDatatype());
     assertEquals(1, output.getProperties().size());
     assertEquals(1, output.getRequiredProperties().size());
-    
+
     assertEquals(DataSchema.BOOLEAN, output.getProperties().get("boolean_value").getDatatype());
     assertTrue(output.getRequiredProperties().contains("boolean_value"));
   }
-  
-  private void assertForm(Form form, String methodName, String target, 
+
+  private void assertForm(Form form, String methodName, String target,
       String contentType, String operationType) {
     assertEquals(methodName, form.getMethodName().get());
     assertEquals(target, form.getTarget());
     assertEquals(contentType, form.getContentType());
     assertTrue(form.hasOperationType(operationType));
   }
-  
+
 }

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
@@ -23,152 +23,154 @@ public class TDGraphWriterTest {
   private static final String THING_TITLE = "My Thing";
   private static final String THING_IRI = "http://example.org/#thing";
   private static final String IO_BASE_IRI = "http://example.org/";
-  
+
   private static final String PREFIXES =
       "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
       "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
       "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" +
       "@prefix dct: <http://purl.org/dc/terms/> .\n" +
       "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
-      "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" + 
-      "@prefix saref: <https://w3id.org/saref#> .\n" + 
+      "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
+      "@prefix saref: <https://w3id.org/saref#> .\n" +
       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n";
-  
+
   @Test
   public void testNoThingURI() throws RDFParseException, RDFHandlerException, IOException {
-    String testTD = 
+    String testTD =
         PREFIXES +
         "\n" +
-        "[] a td:Thing ;\n" + 
+        "[] a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n";
-    
+
     ThingDescription td = (new ThingDescription.Builder(THING_TITLE))
         .addSecurityScheme(new NoSecurityScheme())
         .build();
-    
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteTitle() throws RDFParseException, RDFHandlerException, IOException {
-    String testTD = 
+    String testTD =
         PREFIXES +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n" ;
-    
+
     ThingDescription td = (new ThingDescription.Builder(THING_TITLE))
         .addThingURI(THING_IRI)
         .addSecurityScheme(new NoSecurityScheme())
         .build();
-    
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteAdditionalTypes() throws RDFParseException, RDFHandlerException, IOException {
-    String testTD = 
+    String testTD =
         PREFIXES +
         "@prefix eve: <http://w3id.org/eve#> .\n" +
         "@prefix iot: <http://iotschema.org/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing, eve:Artifact, iot:Light ;\n" + 
+        "<http://example.org/#thing> a td:Thing, eve:Artifact, iot:Light ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n";
-    
+
     ThingDescription td = (new ThingDescription.Builder(THING_TITLE))
         .addThingURI(THING_IRI)
         .addSemanticType("http://w3id.org/eve#Artifact")
         .addSemanticType("http://iotschema.org/Light")
         .addSecurityScheme(new NoSecurityScheme())
         .build();
-    
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
-  public void testWriteTypesDeduplication() throws RDFParseException, RDFHandlerException, 
+  public void testWriteTypesDeduplication() throws RDFParseException, RDFHandlerException,
       IOException {
-    
-    String testTD = 
+
+    String testTD =
         PREFIXES +
         "@prefix eve: <http://w3id.org/eve#> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing, eve:Artifact ;\n" + 
+        "<http://example.org/#thing> a td:Thing, eve:Artifact ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n";
-    
+
     ThingDescription td = (new ThingDescription.Builder(THING_TITLE))
         .addThingURI(THING_IRI)
         .addSemanticType("http://w3id.org/eve#Artifact")
         .addSemanticType("http://w3id.org/eve#Artifact")
         .addSecurityScheme(new NoSecurityScheme())
         .build();
-    
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteBaseURI() throws RDFParseException, RDFHandlerException, IOException {
-    String testTD = 
+    String testTD =
         PREFIXES +
         "\n" +
         "<http://example.org/#thing> a td:Thing ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasBase <http://example.org/> .\n";
-    
+
     ThingDescription td = (new ThingDescription.Builder(THING_TITLE))
         .addThingURI(THING_IRI)
         .addBaseURI("http://example.org/")
         .build();
-    
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteOneAction() throws RDFParseException, RDFHandlerException, IOException {
-    String testTD = 
+    String testTD =
         PREFIXES +
         "@prefix iot: <http://iotschema.org/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-        "    td:hasBase <http://example.org/> ;\n" + 
-        "    td:hasActionAffordance [\n" + 
-        "        a td:ActionAffordance, iot:MyAction ;\n" + 
-        "        dct:title \"My Action\" ;\n" + 
-        "        td:hasForm [\n" + 
-        "            htv:methodName \"PUT\" ;\n" + 
-        "            hctl:hasTarget <http://example.org/action> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:invokeAction;\n" + 
-        "        ] ;\n" + 
-        "        td:hasInputSchema [\n" + 
-        "            a js:ObjectSchema ;\n" + 
-        "            js:properties [\n" + 
+        "    td:hasBase <http://example.org/> ;\n" +
+        "    td:hasActionAffordance [\n" +
+        "        a td:ActionAffordance, iot:MyAction ;\n" +
+        "        td:name \"myAction\" ;\n" +
+        "        dct:title \"My Action\" ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/action> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:invokeAction;\n" +
+        "        ] ;\n" +
+        "        td:hasInputSchema [\n" +
+        "            a js:ObjectSchema ;\n" +
+        "            js:properties [\n" +
         "                a js:NumberSchema ;\n" +
         "                js:propertyName \"number_value\";\n" +
         "            ] ;\n" +
         "            js:required \"number_value\" ;\n" +
-        "        ] ;\n" + 
-        "        td:hasOutputSchema [\n" + 
-        "            a js:ObjectSchema ;\n" + 
-        "            js:properties [\n" + 
+        "        ] ;\n" +
+        "        td:hasOutputSchema [\n" +
+        "            a js:ObjectSchema ;\n" +
+        "            js:properties [\n" +
         "                a js:BooleanSchema ;\n" +
         "                js:propertyName \"boolean_value\";\n" +
         "            ] ;\n" +
         "            js:required \"boolean_value\" ;\n" +
-        "        ]\n" + 
+        "        ]\n" +
         "    ] ." ;
-    
+
     ActionAffordance simpleAction = new ActionAffordance.Builder(
             new Form.Builder( "http://example.org/action")
               .setMethodName("PUT")
               .build())
+        .addName("myAction")
         .addTitle("My Action")
         .addSemanticType("http://iotschema.org/MyAction")
         .addInputSchema(new ObjectSchema.Builder()
@@ -180,46 +182,48 @@ public class TDGraphWriterTest {
             .addRequiredProperties("boolean_value")
             .build())
         .build();
-    
+
     ThingDescription td = (new ThingDescription.Builder(THING_TITLE))
         .addThingURI(THING_IRI)
         .addSecurityScheme(new NoSecurityScheme())
         .addBaseURI("http://example.org/")
         .addAction(simpleAction)
         .build();
-    
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteReadmeExample() throws RDFParseException, RDFHandlerException, IOException {
     String testTD =
         PREFIXES +
-        "\n" + 
-        "<http://example.org/lamp123> a td:Thing, saref:LightSwitch;\n" + 
-        "  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" + 
-        "  dct:title \"My Lamp Thing\" ;\n" + 
-        "  td:hasActionAffordance [ a td:ActionAffordance, saref:ToggleCommand;\n" + 
+        "\n" +
+        "<http://example.org/lamp123> a td:Thing, saref:LightSwitch;\n" +
+        "  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" +
+        "  dct:title \"My Lamp Thing\" ;\n" +
+        "  td:hasActionAffordance [ a td:ActionAffordance, saref:ToggleCommand;\n" +
+        "      td:name \"toggle\";\n" +
         "      dct:title \"Toggle\";\n" +
-        "      td:hasForm [\n" + 
-        "          htv:methodName \"PUT\";\n" + 
-        "          hctl:forContentType \"application/json\";\n" + 
-        "          hctl:hasTarget <http://mylamp.example.org/toggle>;\n" + 
-        "          hctl:hasOperationType td:invokeAction\n" + 
-        "        ];\n" + 
+        "      td:hasForm [\n" +
+        "          htv:methodName \"PUT\";\n" +
+        "          hctl:forContentType \"application/json\";\n" +
+        "          hctl:hasTarget <http://mylamp.example.org/toggle>;\n" +
+        "          hctl:hasOperationType td:invokeAction\n" +
+        "        ];\n" +
         "      td:hasInputSchema [ a saref:OnOffState, js:ObjectSchema;\n" +
-        "          js:properties [ a js:BooleanSchema;\n" + 
-        "              js:propertyName \"status\"\n" + 
-        "            ];\n" + 
-        "          js:required \"status\"\n" + 
-        "        ];\n" + 
+        "          js:properties [ a js:BooleanSchema;\n" +
+        "              js:propertyName \"status\"\n" +
+        "            ];\n" +
+        "          js:required \"status\"\n" +
+        "        ];\n" +
         "    ].";
-    
+
     Form toggleForm = new Form.Builder("http://mylamp.example.org/toggle")
         .setMethodName("PUT")
         .build();
-    
+
     ActionAffordance toggle = new ActionAffordance.Builder(toggleForm)
+        .addName("toggle")
         .addTitle("Toggle")
         .addSemanticType("https://w3id.org/saref#ToggleCommand")
         .addInputSchema(new ObjectSchema.Builder()
@@ -229,21 +233,21 @@ public class TDGraphWriterTest {
             .addRequiredProperties("status")
             .build())
         .build();
-    
+
     ThingDescription td = (new ThingDescription.Builder("My Lamp Thing"))
         .addThingURI("http://example.org/lamp123")
         .addSemanticType("https://w3id.org/saref#LightSwitch")
         .addAction(toggle)
         .build();
-    
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
-  private void assertIsomorphicGraphs(String expectedTD, ThingDescription td) throws RDFParseException, 
+
+  private void assertIsomorphicGraphs(String expectedTD, ThingDescription td) throws RDFParseException,
       RDFHandlerException, IOException {
-    Model expectedModel = ReadWriteTestUtils.readModelFromString(RDFFormat.TURTLE, expectedTD, 
+    Model expectedModel = ReadWriteTestUtils.readModelFromString(RDFFormat.TURTLE, expectedTD,
         IO_BASE_IRI);
-    
+
     String description = new TDGraphWriter(td)
         .setNamespace("td", "https://www.w3.org/2019/wot/td#")
         .setNamespace("htv", "http://www.w3.org/2011/http#")
@@ -253,11 +257,11 @@ public class TDGraphWriterTest {
         .setNamespace("js", "https://www.w3.org/2019/wot/json-schema#")
         .setNamespace("saref", "https://w3id.org/saref#")
         .write();
-    
-    Model tdModel = ReadWriteTestUtils.readModelFromString(RDFFormat.TURTLE, description, 
+
+    Model tdModel = ReadWriteTestUtils.readModelFromString(RDFFormat.TURTLE, description,
         IO_BASE_IRI);
-    
+
     assertTrue(Models.isomorphic(expectedModel, tdModel));
-    
+
   }
 }


### PR DESCRIPTION
In the JSON TD serialization, all affordances have names corresponding to the JSON keys by which affordance objects are indexed. Example: `myProperty` and `myAction` in the TD below.

```json
{
  "id": "urn:ex:myThing",
  "properties": {
    "myProperty": {  }
  },
  "actions": {
    "myAction": { }
  }
}
```

Affordance names are recorded in RDF by [`td:name`](https://www.w3.org/2019/wot/td#name). This PR adds the possibility to read/write affordance names in TDs in RDF.