### PR TITLE
td affordance name required

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ThingDescription td = (new ThingDescription.Builder("My Lamp Thing"))
 The above code snippet creates a `ThingDescription` for a lamp with the title `My Lamp Thing` ([mandatory property](https://www.w3.org/TR/wot-thing-description/#thing)) and the semantic type `saref:LightSwitch` (see [SAREF ontology](https://saref.etsi.org/)). The lamp exposes a `toggle` action, which can be defined in a similar manner:
 
 ```java
-ActionAffordance toggle = new ActionAffordance.Builder(toggleForm)
+ActionAffordance toggle = new ActionAffordance.Builder("Toggle Form", toggleForm)
     .addTitle("Toggle")
     .addSemanticType("https://saref.etsi.org/core/ToggleCommand")
     .addInputSchema(new ObjectSchema.Builder()
@@ -101,6 +101,7 @@ The generated TD is:
   dct:title "My Lamp Thing";
   td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];
   td:hasActionAffordance [ a td:ActionAffordance, saref:ToggleCommand;
+      td:name "Toggle Form";
       dct:title "Toggle";
       td:hasForm [
           htv:methodName "PUT";

--- a/samples/simple_td.ttl
+++ b/samples/simple_td.ttl
@@ -5,35 +5,35 @@
 @prefix wotsec: <https://www.w3.org/2019/wot/security#> .
 @prefix js: <https://www.w3.org/2019/wot/json-schema#> .
 
-<http://example.org/#thing> a td:Thing ; 
+<http://example.org/#thing> a td:Thing ;
     dct:title "My Thing" ;
     td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;
-    td:hasBase <http://example.org/> ; 
-    td:hasActionAffordance [ 
-        a td:ActionAffordance ; 
-        dct:title "My Action" ; 
-        td:hasForm [ 
-            htv:methodName "PUT" ; 
-            hctl:hasTarget <http://example.org/action> ; 
-            hctl:forContentType "application/json"; 
-            hctl:hasOperationType td:invokeAction; 
-        ] ; 
-        td:hasInputSchema [ 
-            a js:ObjectSchema ; 
-            js:properties [ 
+    td:hasBase <http://example.org/> ;
+    td:hasActionAffordance [
+        a td:ActionAffordance ;
+        td:name "My Action" ;
+        td:hasForm [
+            htv:methodName "PUT" ;
+            hctl:hasTarget <http://example.org/action> ;
+            hctl:forContentType "application/json";
+            hctl:hasOperationType td:invokeAction;
+        ] ;
+        td:hasInputSchema [
+            a js:ObjectSchema ;
+            js:properties [
                 a js:NumberSchema ;
                 js:propertyName "number_value";
-                js:maximum 100.05 ; 
+                js:maximum 100.05 ;
                 js:minimum -100.05 ;
             ] ;
             js:required "number_value" ;
-        ] ; 
-        td:hasOutputSchema [ 
-            a js:ObjectSchema ; 
-            js:properties [ 
+        ] ;
+        td:hasOutputSchema [
+            a js:ObjectSchema ;
+            js:properties [
                 a js:BooleanSchema ;
                 js:propertyName "boolean_value";
             ] ;
             js:required "boolean_value" ;
-        ] 
+        ]
     ] .

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
@@ -53,7 +54,7 @@ public class ThingDescription {
       List<ActionAffordance> actions, Optional<Model> graph) {
 
     if (title == null) {
-      throw new IllegalArgumentException("The title of a Thing cannot be null.");
+      throw new InvalidTDException("The title of a Thing cannot be null.");
     }
     this.title = title;
 

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
@@ -19,41 +19,44 @@ import ch.unisg.ics.interactions.wot.td.security.NoSecurityScheme;
 import ch.unisg.ics.interactions.wot.td.security.SecurityScheme;
 
 /**
- * An immutable representation of a <a href="https://www.w3.org/TR/wot-thing-description/">W3C Web of 
- * Things Thing Description (TD)</a>. A <code>ThingDescription</code> is instantiated using a 
+ * An immutable representation of a <a href="https://www.w3.org/TR/wot-thing-description/">W3C Web of
+ * Things Thing Description (TD)</a>. A <code>ThingDescription</code> is instantiated using a
  * <code>ThingDescription.Builder</code>.
- * 
- * The current version does not yet implement all the core vocabulary terms defined by the 
+ *
+ * The current version does not yet implement all the core vocabulary terms defined by the
  * W3C Recommendation.
  */
 public class ThingDescription {
   private final String title;
   private final List<SecurityScheme> security;
-  
+
   private final Optional<String> uri;
   private final Set<String> types;
   private final Optional<String> baseURI;
-  
+
   private final List<PropertyAffordance> properties;
   private final List<ActionAffordance> actions;
-  
+
   private final Optional<Model> graph;
-  
+
   /**
-   * Supported serialization formats -- currently only RDF serialization formats, namely Turtle and 
+   * Supported serialization formats -- currently only RDF serialization formats, namely Turtle and
    * JSON-LD 1.0. The version of JSON-LD currently supported is the one provided by RDF4J.
    */
   public enum TDFormat {
     RDF_TURTLE,
     RDF_JSONLD
   };
-  
-  protected ThingDescription(String title, List<SecurityScheme> security, Optional<String> uri, 
-      Set<String> types, Optional<String> baseURI, List<PropertyAffordance> properties, 
+
+  protected ThingDescription(String title, List<SecurityScheme> security, Optional<String> uri,
+      Set<String> types, Optional<String> baseURI, List<PropertyAffordance> properties,
       List<ActionAffordance> actions, Optional<Model> graph) {
-    
+
+    if (title == null) {
+      throw new IllegalArgumentException("The title of a Thing cannot be null.");
+    }
     this.title = title;
-    
+
     if (security.isEmpty()) {
       security.add(new NoSecurityScheme());
     }
@@ -62,85 +65,85 @@ public class ThingDescription {
     this.uri = uri;
     this.types = types;
     this.baseURI = baseURI;
-    
+
     this.properties = properties;
     this.actions = actions;
-    
+
     this.graph = graph;
   }
-  
+
   public String getTitle() {
     return title;
   }
-  
+
   public List<SecurityScheme> getSecuritySchemes() {
     return security;
   }
-  
+
   /**
    * Gets the first {@link SecurityScheme} that matches a given semantic type.
-   * 
+   *
    * @param type the type of the security scheme
    * @return an <code>Optional</code> with the security scheme (empty if not found)
    */
   public Optional<SecurityScheme> getFirstSecuritySchemeByType(String type) {
     return security.stream().filter(security -> security.getSchemeType().equals(type)).findFirst();
   }
-  
+
   public Optional<String> getThingURI() {
     return uri;
   }
-  
+
   public Set<String> getSemanticTypes() {
     return types;
   }
-  
+
   public Optional<String> getBaseURI() {
     return baseURI;
   }
-  
+
   /**
-   * Gets a set with all the semantic types of the action affordances provided by the described 
+   * Gets a set with all the semantic types of the action affordances provided by the described
    * thing.
-   * 
+   *
    * @return The set of semantic types, can be empty.
    */
   public Set<String> getSupportedActionTypes() {
     Set<String> supportedActionTypes = new HashSet<String>();
-    
+
     for (ActionAffordance action : actions) {
       supportedActionTypes.addAll(action.getSemanticTypes());
     }
-    
+
     return supportedActionTypes;
   }
-  
+
   /**
-   * Gets a property affordance by name, which is specified using the <code>td:name</code> data 
+   * Gets a property affordance by name, which is specified using the <code>td:name</code> data
    * property defined by the TD vocabulary. Names are mandatory in JSON-based representations. If a
-   * name is present, it is unique within the scope of a TD. 
-   * 
-   * @param name the name of the property affordance 
-   * @return an <code>Optional</code> with the property affordance (empty if not found) 
+   * name is present, it is unique within the scope of a TD.
+   *
+   * @param name the name of the property affordance
+   * @return an <code>Optional</code> with the property affordance (empty if not found)
    */
   public Optional<PropertyAffordance> getPropertyByName(String name) {
     for (PropertyAffordance property : properties) {
-      Optional<String> propertyName = property.getName();
-      if (propertyName.isPresent() && propertyName.get().equals(name)) {
+      String propertyName = property.getName();
+      if (propertyName.equals(name)) {
         return Optional.of(property);
       }
     }
 
     return Optional.empty();
   }
-  
+
   /**
-   * Gets a list of property affordances that have a {@link ch.unisg.ics.interactions.wot.td.affordances.Form} 
+   * Gets a list of property affordances that have a {@link ch.unisg.ics.interactions.wot.td.affordances.Form}
    * hypermedia control for the given operation type.
-   * 
+   *
    * The current implementation supports two operation types for properties: <code>td:readProperty</code>
    * and <code>td:writeProperty</code>.
-   * 
+   *
    * @param operationType a string that captures the operation type
    * @return the list of property affordances
    */
@@ -148,10 +151,10 @@ public class ThingDescription {
     return properties.stream().filter(property -> property.hasFormWithOperationType(operationType))
         .collect(Collectors.toList());
   }
-  
+
   /**
    * Gets the first {@link PropertyAffordance} annotated with a given semantic type.
-   * 
+   *
    * @param propertyType the semantic type, typically and IRI defined in some ontology
    * @return an <code>Optional</code> with the property affordance (empty if not found)
    */
@@ -161,36 +164,36 @@ public class ThingDescription {
         return Optional.of(property);
       }
     }
-    
+
     return Optional.empty();
   }
-  
+
   /**
-   * Gets an action affordance by name, which is specified using the <code>td:name</code> data 
+   * Gets an action affordance by name, which is specified using the <code>td:name</code> data
    * property defined by the TD vocabulary. Names are mandatory in JSON-based representations. If a
-   * name is present, it is unique within the scope of a TD. 
-   * 
-   * @param name the name of the action affordance 
-   * @return an <code>Optional</code> with the action affordance (empty if not found) 
+   * name is present, it is unique within the scope of a TD.
+   *
+   * @param name the name of the action affordance
+   * @return an <code>Optional</code> with the action affordance (empty if not found)
    */
   public Optional<ActionAffordance> getActionByName(String name) {
     for (ActionAffordance action : actions) {
-      Optional<String> actionName = action.getName();
-      if (actionName.isPresent() && actionName.get().equals(name)) {
+      String actionName = action.getName();
+      if (actionName.equals(name)) {
         return Optional.of(action);
       }
     }
-    
+
     return Optional.empty();
   }
-  
+
   /**
-   * Gets a list of action affordances that have a {@link ch.unisg.ics.interactions.wot.td.affordances.Form} 
+   * Gets a list of action affordances that have a {@link ch.unisg.ics.interactions.wot.td.affordances.Form}
    * hypermedia control for the given operation type.
-   * 
-   * There is one operation type available actions: <code>td:invokeAction</code>. The API will be 
+   *
+   * There is one operation type available actions: <code>td:invokeAction</code>. The API will be
    * simplified in future iterations.
-   * 
+   *
    * @param operationType a string that captures the operation type
    * @return the list of property affordances
    */
@@ -198,10 +201,10 @@ public class ThingDescription {
     return actions.stream().filter(action -> action.hasFormWithOperationType(operationType))
         .collect(Collectors.toList());
   }
-  
+
   /**
    * Gets the first {@link ActionAffordance} annotated with a given semantic type.
-   * 
+   *
    * @param actionType the semantic type, typically and IRI defined in some ontology
    * @return an <code>Optional</code> with the action affordance (empty if not found)
    */
@@ -211,109 +214,109 @@ public class ThingDescription {
         return Optional.of(action);
       }
     }
-    
+
     return Optional.empty();
   }
-  
+
   public List<PropertyAffordance> getProperties() {
     return this.properties;
   }
-  
+
   public List<ActionAffordance> getActions() {
     return this.actions;
   }
-  
+
   public Optional<Model> getGraph() {
     return graph;
   }
-  
+
   /**
    * Helper class used to construct a <code>ThingDescription</code>. All TDs should have a mandatory
-   * <code>title</code> field. In addition to the optional fields defined by the W3C Recommendation, 
+   * <code>title</code> field. In addition to the optional fields defined by the W3C Recommendation,
    * the <code>addGraph</code> method allows to add any other metadata as an RDF graph.
-   * 
+   *
    * Implements a fluent API.
    */
   public static class Builder {
     private final String title;
     private final List<SecurityScheme> security;
-    
+
     private Optional<String> uri;
     private Optional<String> baseURI;
     private final Set<String> types;
-    
+
     private final List<PropertyAffordance> properties;
     private final List<ActionAffordance> actions;
-    
+
     private Optional<Model> graph;
-    
+
     public Builder(String title) {
       this.title = title;
       this.security = new ArrayList<SecurityScheme>();
-      
+
       this.uri = Optional.empty();
       this.baseURI = Optional.empty();
       this.types= new HashSet<String>();
-      
+
       this.properties = new ArrayList<PropertyAffordance>();
       this.actions = new ArrayList<ActionAffordance>();
-      
+
       this.graph = Optional.empty();
     }
-    
+
     public Builder addSecurityScheme(SecurityScheme security) {
       this.security.add(security);
       return this;
     }
-    
+
     public Builder addSecuritySchemes(List<SecurityScheme> security) {
       this.security.addAll(security);
       return this;
     }
-    
+
     public Builder addThingURI(String uri) {
       this.uri = Optional.of(uri);
       return this;
     }
-    
+
     public Builder addBaseURI(String baseURI) {
       this.baseURI = Optional.of(baseURI);
       return this;
     }
-    
+
     public Builder addSemanticType(String type) {
       this.types.add(type);
       return this;
     }
-    
+
     public Builder addSemanticTypes(Set<String> thingTypes) {
       this.types.addAll(thingTypes);
       return this;
     }
-    
+
     public Builder addProperty(PropertyAffordance property) {
       this.properties.add(property);
       return this;
     }
-    
+
     public Builder addProperties(List<PropertyAffordance> properties) {
       this.properties.addAll(properties);
       return this;
     }
-    
+
     public Builder addAction(ActionAffordance action) {
       this.actions.add(action);
       return this;
     }
-    
+
     public Builder addActions(List<ActionAffordance> actions) {
       this.actions.addAll(actions);
       return this;
     }
-    
+
     /**
-     * Adds an RDF graph. If an RDF graph is already present, it will be merged with the new graph. 
-     * 
+     * Adds an RDF graph. If an RDF graph is already present, it will be merged with the new graph.
+     *
      * @param graph the RDF graph to be added
      * @return this <code>Builder</code>
      */
@@ -323,14 +326,14 @@ public class ThingDescription {
       } else {
         this.graph = Optional.of(graph);
       }
-      
+
       return this;
     }
-    
+
     /**
      * Convenience method used to add a single triple. If an RDF graph is already present, the triple
      * will be added to the existing graph.
-     * 
+     *
      * @param subject the subject
      * @param predicate the predicate
      * @param object the object
@@ -342,13 +345,13 @@ public class ThingDescription {
       } else {
         this.graph = Optional.of(new ModelBuilder().add(subject, predicate, object).build());
       }
-      
+
       return this;
     }
-    
+
     /**
      * Constructs and returns a <code>ThingDescription</code>.
-     * 
+     *
      * @return the constructed <code>ThingDescription</code>
      */
     public ThingDescription build() {

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/ThingDescription.java
@@ -1,29 +1,24 @@
 package ch.unisg.ics.interactions.wot.td;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
+import ch.unisg.ics.interactions.wot.td.affordances.PropertyAffordance;
 import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
+import ch.unisg.ics.interactions.wot.td.security.NoSecurityScheme;
+import ch.unisg.ics.interactions.wot.td.security.SecurityScheme;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 
-import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
-import ch.unisg.ics.interactions.wot.td.affordances.PropertyAffordance;
-import ch.unisg.ics.interactions.wot.td.security.NoSecurityScheme;
-import ch.unisg.ics.interactions.wot.td.security.SecurityScheme;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * An immutable representation of a <a href="https://www.w3.org/TR/wot-thing-description/">W3C Web of
  * Things Thing Description (TD)</a>. A <code>ThingDescription</code> is instantiated using a
  * <code>ThingDescription.Builder</code>.
- *
+ * <p>
  * The current version does not yet implement all the core vocabulary terms defined by the
  * W3C Recommendation.
  */
@@ -40,18 +35,9 @@ public class ThingDescription {
 
   private final Optional<Model> graph;
 
-  /**
-   * Supported serialization formats -- currently only RDF serialization formats, namely Turtle and
-   * JSON-LD 1.0. The version of JSON-LD currently supported is the one provided by RDF4J.
-   */
-  public enum TDFormat {
-    RDF_TURTLE,
-    RDF_JSONLD
-  };
-
   protected ThingDescription(String title, List<SecurityScheme> security, Optional<String> uri,
-      Set<String> types, Optional<String> baseURI, List<PropertyAffordance> properties,
-      List<ActionAffordance> actions, Optional<Model> graph) {
+                             Set<String> types, Optional<String> baseURI, List<PropertyAffordance> properties,
+                             List<ActionAffordance> actions, Optional<Model> graph) {
 
     if (title == null) {
       throw new InvalidTDException("The title of a Thing cannot be null.");
@@ -141,7 +127,7 @@ public class ThingDescription {
   /**
    * Gets a list of property affordances that have a {@link ch.unisg.ics.interactions.wot.td.affordances.Form}
    * hypermedia control for the given operation type.
-   *
+   * <p>
    * The current implementation supports two operation types for properties: <code>td:readProperty</code>
    * and <code>td:writeProperty</code>.
    *
@@ -150,7 +136,7 @@ public class ThingDescription {
    */
   public List<PropertyAffordance> getPropertiesByOperationType(String operationType) {
     return properties.stream().filter(property -> property.hasFormWithOperationType(operationType))
-        .collect(Collectors.toList());
+      .collect(Collectors.toList());
   }
 
   /**
@@ -191,7 +177,7 @@ public class ThingDescription {
   /**
    * Gets a list of action affordances that have a {@link ch.unisg.ics.interactions.wot.td.affordances.Form}
    * hypermedia control for the given operation type.
-   *
+   * <p>
    * There is one operation type available actions: <code>td:invokeAction</code>. The API will be
    * simplified in future iterations.
    *
@@ -200,7 +186,7 @@ public class ThingDescription {
    */
   public List<ActionAffordance> getActionsByOperationType(String operationType) {
     return actions.stream().filter(action -> action.hasFormWithOperationType(operationType))
-        .collect(Collectors.toList());
+      .collect(Collectors.toList());
   }
 
   /**
@@ -232,23 +218,29 @@ public class ThingDescription {
   }
 
   /**
+   * Supported serialization formats -- currently only RDF serialization formats, namely Turtle and
+   * JSON-LD 1.0. The version of JSON-LD currently supported is the one provided by RDF4J.
+   */
+  public enum TDFormat {
+    RDF_TURTLE,
+    RDF_JSONLD
+  }
+
+  /**
    * Helper class used to construct a <code>ThingDescription</code>. All TDs should have a mandatory
    * <code>title</code> field. In addition to the optional fields defined by the W3C Recommendation,
    * the <code>addGraph</code> method allows to add any other metadata as an RDF graph.
-   *
+   * <p>
    * Implements a fluent API.
    */
   public static class Builder {
     private final String title;
     private final List<SecurityScheme> security;
-
-    private Optional<String> uri;
-    private Optional<String> baseURI;
     private final Set<String> types;
-
     private final List<PropertyAffordance> properties;
     private final List<ActionAffordance> actions;
-
+    private Optional<String> uri;
+    private Optional<String> baseURI;
     private Optional<Model> graph;
 
     public Builder(String title) {
@@ -257,7 +249,7 @@ public class ThingDescription {
 
       this.uri = Optional.empty();
       this.baseURI = Optional.empty();
-      this.types= new HashSet<String>();
+      this.types = new HashSet<String>();
 
       this.properties = new ArrayList<PropertyAffordance>();
       this.actions = new ArrayList<ActionAffordance>();
@@ -335,9 +327,9 @@ public class ThingDescription {
      * Convenience method used to add a single triple. If an RDF graph is already present, the triple
      * will be added to the existing graph.
      *
-     * @param subject the subject
+     * @param subject   the subject
      * @param predicate the predicate
-     * @param object the object
+     * @param object    the object
      * @return this <code>Builder</code>
      */
     public Builder addTriple(Resource subject, IRI predicate, Value object) {

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/ActionAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/ActionAffordance.java
@@ -1,79 +1,78 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
+import ch.unisg.ics.interactions.wot.td.schemas.DataSchema;
+import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import ch.unisg.ics.interactions.wot.td.schemas.DataSchema;
-import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
-
 /**
  * TODO: add javadoc
- * 
- * @author Andrei Ciortea
  *
+ * @author Andrei Ciortea
  */
 public class ActionAffordance extends InteractionAffordance {
   final private Optional<DataSchema> input;
   final private Optional<DataSchema> output;
-  
+
   // TODO: add safe, idempotent
-  
-  private ActionAffordance(Optional<String> name, Optional<String> title, List<String> types, 
-      List<Form> forms, Optional<DataSchema> input, Optional<DataSchema> output) {
+
+  private ActionAffordance(String name, Optional<String> title, List<String> types,
+                           List<Form> forms, Optional<DataSchema> input, Optional<DataSchema> output) {
     super(name, title, types, forms);
     this.input = input;
     this.output = output;
   }
-  
+
   public Optional<Form> getFirstForm() {
     return getFirstFormForOperationType(TD.invokeAction);
   }
-  
+
   public Optional<DataSchema> getInputSchema() {
     return input;
   }
-  
+
   public Optional<DataSchema> getOutputSchema() {
     return output;
   }
-  
-  public static class Builder 
-      extends InteractionAffordance.Builder<ActionAffordance, ActionAffordance.Builder> {
-    
+
+  public static class Builder
+    extends InteractionAffordance.Builder<ActionAffordance, ActionAffordance.Builder> {
+
     private Optional<DataSchema> inputSchema;
     private Optional<DataSchema> outputSchema;
-    
-    public Builder(List<Form> forms) {
-      super(forms);
-      
+
+    public Builder(String name, List<Form> forms) {
+      super(name, forms);
+
       for (Form form : this.forms) {
         form.addOperationType(TD.invokeAction);
-        
+
         if (!form.getMethodName().isPresent()) {
           form.setMethodName("POST");
         }
       }
-      
+
       this.inputSchema = Optional.empty();
       this.outputSchema = Optional.empty();
     }
-    
-    public Builder(Form form) {
-      this(new ArrayList<Form>(Arrays.asList(form)));
+
+    public Builder(String name, Form form) {
+      this(name, new ArrayList<Form>(Arrays.asList(form)));
     }
-    
+
     public Builder addInputSchema(DataSchema inputSchema) {
       this.inputSchema = Optional.of(inputSchema);
       return this;
     }
-    
+
     public Builder addOutputSchema(DataSchema outputSchema) {
       this.outputSchema = Optional.of(outputSchema);
       return this;
     }
-    
+
     public ActionAffordance build() {
       return new ActionAffordance(name, title, types, forms, inputSchema, outputSchema);
     }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
@@ -1,5 +1,7 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
+import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,7 +26,7 @@ public class InteractionAffordance {
   protected InteractionAffordance(String name, Optional<String> title, List<String> types,
                                   List<Form> forms) {
     if (name == null) {
-      throw new IllegalArgumentException("The name of an affordance cannot be null.");
+      throw new InvalidTDException("The name of an affordance cannot be null.");
     }
     this.name = name;
     this.title = title;

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
@@ -8,138 +8,136 @@ import java.util.stream.Collectors;
 
 /**
  * TODO: add javadoc
- * 
- * @author Andrei Ciortea
  *
+ * @author Andrei Ciortea
  */
 public class InteractionAffordance {
   public static final String PROPERTY = "property";
   public static final String EVENT = "event";
   public static final String ACTION = "action";
-  
-  protected Optional<String> name;
+
+  protected final String name;
   protected Optional<String> title;
   protected List<String> types;
   protected List<Form> forms;
-  
-  protected InteractionAffordance(Optional<String> name, Optional<String> title, List<String> types, 
-      List<Form> forms) {
+
+  protected InteractionAffordance(String name, Optional<String> title, List<String> types,
+                                  List<Form> forms) {
+    if (name == null) {
+      throw new IllegalArgumentException("The name of an affordance cannot be null.");
+    }
     this.name = name;
     this.title = title;
     this.types = types;
     this.forms = forms;
   }
-  
-  public Optional<String> getName() {
+
+  public String getName() {
     return name;
   }
-  
+
   public Optional<String> getTitle() {
     return title;
   }
-  
+
   public List<String> getSemanticTypes() {
     return types;
   }
-  
+
   public List<Form> getForms() {
     return forms;
   }
-  
+
   public boolean hasFormWithOperationType(String operationType) {
     return !forms.stream().filter(form -> form.hasOperationType(operationType))
-        .collect(Collectors.toList()).isEmpty();
+      .collect(Collectors.toList()).isEmpty();
   }
-  
+
   public Optional<Form> getFirstFormForOperationType(String operationType) {
     if (hasFormWithOperationType(operationType)) {
       Form firstForm = forms.stream().filter(form -> form.hasOperationType(operationType))
-          .collect(Collectors.toList()).get(0);
-      
+        .collect(Collectors.toList()).get(0);
+
       return Optional.of(firstForm);
     }
-    
+
     return Optional.empty();
   }
-  
+
   public boolean hasSemanticType(String type) {
     return this.types.contains(type);
   }
-  
+
   public boolean hasOneSemanticType(List<String> types) {
     for (String type : types) {
       if (this.types.contains(type)) {
         return true;
       }
     }
-    
+
     return false;
   }
-  
+
   public boolean hasAllSemanticTypes(List<String> types) {
     for (String type : types) {
       if (!this.types.contains(type)) {
         return false;
       }
     }
-    
+
     return true;
   }
-  
-  /** Abstract builder for interaction affordances. */
-  public static abstract class Builder<T extends InteractionAffordance, S extends Builder<T,S>> {
-    protected Optional<String> name;
+
+  /**
+   * Abstract builder for interaction affordances.
+   */
+  public static abstract class Builder<T extends InteractionAffordance, S extends Builder<T, S>> {
+    protected final String name;
     protected Optional<String> title;
     protected List<String> types;
     protected List<Form> forms;
-    
-    protected Builder(Form form) {
-      this(new ArrayList<Form>(Arrays.asList(form)));
+
+    protected Builder(String name, Form form) {
+      this(name, new ArrayList<Form>(Arrays.asList(form)));
     }
-    
-    protected Builder(List<Form> forms) {
-      this.name = Optional.empty();
+
+    protected Builder(String name, List<Form> forms) {
+      this.name = name;
       this.title = Optional.empty();
       this.types = new ArrayList<String>();
       this.forms = forms;
     }
-    
-    @SuppressWarnings("unchecked")
-    public S addName(String name) {
-      this.name = Optional.of(name);
-      return (S) this;
-    }
-    
+
     @SuppressWarnings("unchecked")
     public S addTitle(String title) {
       this.title = Optional.of(title);
       return (S) this;
     }
-    
+
     @SuppressWarnings("unchecked")
     public S addSemanticType(String type) {
       this.types.add(type);
       return (S) this;
     }
-    
+
     @SuppressWarnings("unchecked")
     public S addSemanticTypes(List<String> types) {
       this.types.addAll(types);
       return (S) this;
     }
-    
+
     @SuppressWarnings("unchecked")
     public S addForm(Form form) {
       this.forms.add(form);
       return (S) this;
     }
-    
+
     @SuppressWarnings("unchecked")
     public S addForms(List<Form> forms) {
       this.forms.addAll(forms);
       return (S) this;
     }
-    
+
     public abstract T build();
   }
 }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/PropertyAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/PropertyAffordance.java
@@ -1,61 +1,61 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
+import ch.unisg.ics.interactions.wot.td.schemas.DataSchema;
+import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import ch.unisg.ics.interactions.wot.td.schemas.DataSchema;
-import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
-
 public class PropertyAffordance extends InteractionAffordance {
   private final DataSchema schema;
   private final boolean observable;
-  
-  private PropertyAffordance(Optional<String> name, DataSchema schema, boolean observable, 
-      Optional<String> title, List<String> types, List<Form> forms) {
+
+  private PropertyAffordance(String name, DataSchema schema, boolean observable,
+                             Optional<String> title, List<String> types, List<Form> forms) {
     super(name, title, types, forms);
     this.schema = schema;
     this.observable = observable;
   }
-  
+
   public DataSchema getDataSchema() {
     return schema;
   }
-  
+
   public boolean isObservable() {
     return observable;
   }
-  
-  public static class Builder 
-      extends InteractionAffordance.Builder<PropertyAffordance, PropertyAffordance.Builder> {
+
+  public static class Builder
+    extends InteractionAffordance.Builder<PropertyAffordance, PropertyAffordance.Builder> {
 
     private final DataSchema schema;
     private boolean observable;
-    
-    public Builder(DataSchema schema, List<Form> forms) {
-      super(forms);
-      
+
+    public Builder(String name, DataSchema schema, List<Form> forms) {
+      super(name, forms);
+
       for (Form form : this.forms) {
         if (form.getOperationTypes().isEmpty()) {
           form.addOperationType(TD.readProperty);
           form.addOperationType(TD.writeProperty);
         }
       }
-      
+
       this.schema = schema;
       this.observable = false;
     }
-    
-    public Builder(DataSchema schema, Form form) {
-      this(schema, new ArrayList<Form>(Arrays.asList(form)));
+
+    public Builder(String name, DataSchema schema, Form form) {
+      this(name, schema, new ArrayList<Form>(Arrays.asList(form)));
     }
-    
+
     public Builder addObserve() {
       this.observable = true;
       return this;
     }
-    
+
     @Override
     public PropertyAffordance build() {
       return new PropertyAffordance(name, schema, observable, title, types, forms);

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReader.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReader.java
@@ -1,33 +1,5 @@
 package ch.unisg.ics.interactions.wot.td.io;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.apache.hc.client5.http.fluent.Request;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.util.Models;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-
 import ch.unisg.ics.interactions.wot.td.ThingDescription;
 import ch.unisg.ics.interactions.wot.td.ThingDescription.TDFormat;
 import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
@@ -40,89 +12,103 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.DCT;
 import ch.unisg.ics.interactions.wot.td.vocabularies.HCTL;
 import ch.unisg.ics.interactions.wot.td.vocabularies.HTV;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+import org.apache.hc.client5.http.fluent.Request;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.rio.*;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A reader for deserializing TDs from RDF representations. The created <code>ThingDescription</code>
- * maintains the full RDF graph read as input, which can be retrieved with the <code>getGraph</code> 
+ * maintains the full RDF graph read as input, which can be retrieved with the <code>getGraph</code>
  * method.
- *
  */
 public class TDGraphReader {
   private final Resource thingId;
-  private Model model;
   private final ValueFactory rdf = SimpleValueFactory.getInstance();
-  
+  private Model model;
+
+  TDGraphReader(RDFFormat format, String representation) {
+    loadModel(format, representation, "");
+
+    Optional<String> baseURI = readBaseURI();
+    if (baseURI.isPresent()) {
+      loadModel(format, representation, baseURI.get());
+    }
+
+    try {
+      thingId = Models.subject(model.filter(null, rdf.createIRI(TD.hasSecurityConfiguration),
+        null)).get();
+    } catch (NoSuchElementException e) {
+      throw new InvalidTDException("Missing mandatory security definitions.", e);
+    }
+  }
+
   public static ThingDescription readFromURL(TDFormat format, String url) throws IOException {
     String representation = Request.get(url).execute().returnContent().asString();
     return readFromString(format, representation);
   }
-  
+
   /**
    * Returns a ThingDescription object based on the path parameter that points to a file. Should the path be invalid
    * or if the file does not exist, an IOException is thrown.
-   * 
-   * @param	format	the file's thing description
-   * @param path	the location of the file that contains the thing description
-   * @return	the thing description
+   *
+   * @param path the location of the file that contains the thing description
+   * @param  format  the file's thing description
+   * @return the thing description
    */
   public static ThingDescription readFromFile(TDFormat format, String path) throws IOException {
     String content = new String(Files.readAllBytes(Paths.get(path)));
     return readFromString(format, content);
   }
-  
+
   public static ThingDescription readFromString(TDFormat format, String representation) {
     TDGraphReader reader;
-    
+
     if (format == TDFormat.RDF_TURTLE) {
       reader = new TDGraphReader(RDFFormat.TURTLE, representation);
     } else {
       reader = new TDGraphReader(RDFFormat.JSONLD, representation);
     }
-    
+
     ThingDescription.Builder tdBuilder = new ThingDescription.Builder(reader.readThingTitle())
-        .addSemanticTypes(reader.readThingTypes())
-        .addSecuritySchemes(reader.readSecuritySchemes())
-        .addProperties(reader.readProperties())
-        .addActions(reader.readActions())
-        .addGraph(reader.getGraph());
-    
+      .addSemanticTypes(reader.readThingTypes())
+      .addSecuritySchemes(reader.readSecuritySchemes())
+      .addProperties(reader.readProperties())
+      .addActions(reader.readActions())
+      .addGraph(reader.getGraph());
+
     Optional<String> thingURI = reader.getThingURI();
     if (thingURI.isPresent()) {
       tdBuilder.addThingURI(thingURI.get());
     }
-    
+
     Optional<String> base = reader.readBaseURI();
     if (base.isPresent()) {
       tdBuilder.addBaseURI(base.get());
     }
-    
+
     return tdBuilder.build();
   }
-  
-  TDGraphReader(RDFFormat format, String representation) {
-    loadModel(format, representation, "");
-    
-    Optional<String> baseURI = readBaseURI();
-    if (baseURI.isPresent()) {
-      loadModel(format, representation, baseURI.get());
-    }
-    
-    try {
-      thingId = Models.subject(model.filter(null, rdf.createIRI(TD.hasSecurityConfiguration), 
-          null)).get();
-    } catch (NoSuchElementException e) {
-      throw new InvalidTDException("Missing mandatory security definitions.", e);
-    }
-  }
-  
+
   private void loadModel(RDFFormat format, String representation, String baseURI) {
     this.model = new LinkedHashModel();
-    
+
     RDFParser parser = Rio.createParser(format);
     parser.setRDFHandler(new StatementCollector(model));
 
     StringReader stringReader = new StringReader(representation);
-    
+
     try {
       parser.parse(stringReader, baseURI);
     } catch (RDFParseException | RDFHandlerException | IOException e) {
@@ -131,130 +117,136 @@ public class TDGraphReader {
       stringReader.close();
     }
   }
-  
+
   Model getGraph() {
     return model;
   }
-  
+
   Optional<String> getThingURI() {
     if (thingId instanceof IRI) {
       return Optional.of(thingId.stringValue());
     }
-    
+
     return Optional.empty();
   }
-  
+
   String readThingTitle() {
-  	Literal thingTitle;
-  	
+    Literal thingTitle;
+
     try {
-      thingTitle = Models.objectLiteral(model.filter(thingId, rdf.createIRI(DCT.title), null)).get();    	
+      thingTitle = Models.objectLiteral(model.filter(thingId, rdf.createIRI(DCT.title), null)).get();
     } catch (NoSuchElementException e) {
       throw new InvalidTDException("Missing mandatory title.", e);
     }
-    
+
     return thingTitle.stringValue();
   }
-  
+
   Set<String> readThingTypes() {
     Set<IRI> thingTypes = Models.objectIRIs(model.filter(thingId, RDF.TYPE, null));
-    
+
     return thingTypes.stream()
-        .map(iri -> iri.stringValue())
-        .collect(Collectors.toSet());
+      .map(iri -> iri.stringValue())
+      .collect(Collectors.toSet());
   }
-  
+
   final Optional<String> readBaseURI() {
     Optional<IRI> baseURI = Models.objectIRI(model.filter(thingId, rdf.createIRI(TD.hasBase), null));
-    
+
     if (baseURI.isPresent()) {
       return Optional.of(baseURI.get().stringValue());
     }
-    
+
     return Optional.empty();
   }
-  
+
   List<SecurityScheme> readSecuritySchemes() {
-    Set<Resource> nodeIds = Models.objectResources(model.filter(thingId, 
-        rdf.createIRI(TD.hasSecurityConfiguration), null));
-    
+    Set<Resource> nodeIds = Models.objectResources(model.filter(thingId,
+      rdf.createIRI(TD.hasSecurityConfiguration), null));
+
     List<SecurityScheme> schemes = new ArrayList<SecurityScheme>();
-    
+
     for (Resource node : nodeIds) {
       Optional<IRI> securityScheme = Models.objectIRI(model.filter(node, RDF.TYPE, null));
-      
+
       if (securityScheme.isPresent()) {
-        Optional<SecurityScheme> scheme = SecurityScheme.fromRDF(securityScheme.get().stringValue(), 
-            model, node);
-        
+        Optional<SecurityScheme> scheme = SecurityScheme.fromRDF(securityScheme.get().stringValue(),
+          model, node);
+
         if (scheme.isPresent()) {
           schemes.add(scheme.get());
         }
       }
     }
-    
+
     return schemes;
   }
-  
+
   List<PropertyAffordance> readProperties() {
     List<PropertyAffordance> properties = new ArrayList<PropertyAffordance>();
-    
-    Set<Resource> propertyIds = Models.objectResources(model.filter(thingId, 
-        rdf.createIRI(TD.hasPropertyAffordance), null));
-    
+
+    Set<Resource> propertyIds = Models.objectResources(model.filter(thingId,
+      rdf.createIRI(TD.hasPropertyAffordance), null));
+
     for (Resource propertyId : propertyIds) {
       try {
         Optional<DataSchema> schema = SchemaGraphReader.readDataSchema(propertyId, model);
-        
+
         if (schema.isPresent()) {
           List<Form> forms = readForms(propertyId, InteractionAffordance.PROPERTY);
-          PropertyAffordance.Builder builder = new PropertyAffordance.Builder(schema.get(), forms);
-          
+          String name = readAffordanceName(propertyId);
+          PropertyAffordance.Builder builder = new PropertyAffordance.Builder(name, schema.get(),
+            forms);
+
           readAffordanceMetadata(builder, propertyId);
-          
-          Optional<Literal> observable = Models.objectLiteral(model.filter(propertyId, 
-              rdf.createIRI(TD.isObservable), null));
+
+          Optional<Literal> observable = Models.objectLiteral(model.filter(propertyId,
+            rdf.createIRI(TD.isObservable), null));
           if (observable.isPresent() && observable.get().booleanValue()) {
             builder.addObserve();
           }
-          
+
           properties.add(builder.build());
         }
       } catch (InvalidTDException e) {
         throw new InvalidTDException("Invalid property definition.", e);
       }
     }
-    
+
     return properties;
   }
-  
+
   List<ActionAffordance> readActions() {
     List<ActionAffordance> actions = new ArrayList<ActionAffordance>();
-    
-    Set<Resource> affordanceIds = Models.objectResources(model.filter(thingId, 
-        rdf.createIRI(TD.hasActionAffordance), null));
-    
+
+    Set<Resource> affordanceIds = Models.objectResources(model.filter(thingId,
+      rdf.createIRI(TD.hasActionAffordance), null));
+
     for (Resource affordanceId : affordanceIds) {
       if (!model.contains(affordanceId, RDF.TYPE, rdf.createIRI(TD.ActionAffordance))) {
         continue;
       }
-      
-      ActionAffordance action = readAction(affordanceId);
-      actions.add(action);
+      try {
+        ActionAffordance action = readAction(affordanceId);
+        actions.add(action);
+      } catch (InvalidTDException e) {
+        throw new InvalidTDException("Invalid action definition.", e);
+      }
     }
-    
+
     return actions;
   }
-  
+
   private ActionAffordance readAction(Resource affordanceId) {
     List<Form> forms = readForms(affordanceId, InteractionAffordance.ACTION);
-    ActionAffordance.Builder actionBuilder = new ActionAffordance.Builder(forms);
-    
+    String name = readAffordanceName(affordanceId);
+    ActionAffordance.Builder actionBuilder = new ActionAffordance.Builder(name, forms);
+
     readAffordanceMetadata(actionBuilder, affordanceId);
-    
+
     try {
-      Optional<Resource> inputSchemaId = Models.objectResource(model.filter(affordanceId, 
-          rdf.createIRI(TD.hasInputSchema), null));
+      Optional<Resource> inputSchemaId = Models.objectResource(model.filter(affordanceId,
+        rdf.createIRI(TD.hasInputSchema), null));
       if (inputSchemaId.isPresent()) {
         try {
           Optional<DataSchema> input = SchemaGraphReader.readDataSchema(inputSchemaId.get(), model);
@@ -265,95 +257,101 @@ public class TDGraphReader {
           throw new InvalidTDException("Invalid action definition.", e);
         }
       }
-      
-      Optional<Resource> outSchemaId = Models.objectResource(model.filter(affordanceId, 
-          rdf.createIRI(TD.hasOutputSchema), null));
+
+      Optional<Resource> outSchemaId = Models.objectResource(model.filter(affordanceId,
+        rdf.createIRI(TD.hasOutputSchema), null));
       if (outSchemaId.isPresent()) {
-          Optional<DataSchema> output = SchemaGraphReader.readDataSchema(outSchemaId.get(), model);
-          if (output.isPresent()) {
-            actionBuilder.addOutputSchema(output.get());
-          }
+        Optional<DataSchema> output = SchemaGraphReader.readDataSchema(outSchemaId.get(), model);
+        if (output.isPresent()) {
+          actionBuilder.addOutputSchema(output.get());
+        }
       }
     } catch (InvalidTDException e) {
       throw new InvalidTDException("Invalid action definition.", e);
     }
-    
+
     return actionBuilder.build();
   }
-  
+
+  private String readAffordanceName(Resource affordanceId) {
+    Literal affordanceName;
+
+    try {
+      affordanceName = Models.objectLiteral(model.filter(affordanceId, rdf.createIRI(TD.name),
+        null)).get();
+    } catch (NoSuchElementException e) {
+      throw new InvalidTDException("Missing mandatory affordance name.", e);
+    }
+
+    return affordanceName.stringValue();
+  }
+
   private void readAffordanceMetadata(InteractionAffordance
-      .Builder<?, ? extends InteractionAffordance.Builder<?,?>> builder, Resource affordanceId) {
+                                        .Builder<?, ? extends InteractionAffordance.Builder<?, ?>> builder, Resource affordanceId) {
     /* Read semantic types */
     Set<IRI> types = Models.objectIRIs(model.filter(affordanceId, RDF.TYPE, null));
     builder.addSemanticTypes(types.stream().map(type -> type.stringValue())
-        .collect(Collectors.toList()));
-    
-    /* Read name */
-    Optional<Literal> name = Models.objectLiteral(model.filter(affordanceId, rdf.createIRI(TD.name), 
-        null));
-    if (name.isPresent()) {
-      builder.addName(name.get().stringValue());
-    }
-    
+      .collect(Collectors.toList()));
+
     /* Read title */
-    Optional<Literal> title = Models.objectLiteral(model.filter(affordanceId, 
-        rdf.createIRI(DCT.title), null));
+    Optional<Literal> title = Models.objectLiteral(model.filter(affordanceId,
+      rdf.createIRI(DCT.title), null));
     if (title.isPresent()) {
       builder.addTitle(title.get().stringValue());
     }
   }
-  
+
   private List<Form> readForms(Resource affordanceId, String affordanceType) {
     List<Form> forms = new ArrayList<Form>();
-    
-    Set<Resource> formIdSet = Models.objectResources(model.filter(affordanceId, 
-        rdf.createIRI(TD.hasForm), null));
-    
+
+    Set<Resource> formIdSet = Models.objectResources(model.filter(affordanceId,
+      rdf.createIRI(TD.hasForm), null));
+
     for (Resource formId : formIdSet) {
-      Optional<IRI> targetOpt = Models.objectIRI(model.filter(formId, rdf.createIRI(HCTL.hasTarget), 
-          null));
-      
+      Optional<IRI> targetOpt = Models.objectIRI(model.filter(formId, rdf.createIRI(HCTL.hasTarget),
+        null));
+
       if (!targetOpt.isPresent()) {
         continue;
       }
-      
-      Optional<Literal> methodNameOpt = Models.objectLiteral(model.filter(formId, 
-          rdf.createIRI(HTV.methodName), null));
-      
-      Optional<Literal> contentTypeOpt = Models.objectLiteral(model.filter(formId, 
-          rdf.createIRI(HCTL.forContentType), null));
-      String contentType = contentTypeOpt.isPresent() ? contentTypeOpt.get().stringValue() 
-          : "application/json";
-      
-      Optional<Literal> subprotocolOpt = Models.objectLiteral(model.filter(formId, 
-          rdf.createIRI(HCTL.forSubProtocol), null));
-      
-      Set<IRI> opsIRIs = Models.objectIRIs(model.filter(formId, rdf.createIRI(HCTL.hasOperationType), 
-          null));
+
+      Optional<Literal> methodNameOpt = Models.objectLiteral(model.filter(formId,
+        rdf.createIRI(HTV.methodName), null));
+
+      Optional<Literal> contentTypeOpt = Models.objectLiteral(model.filter(formId,
+        rdf.createIRI(HCTL.forContentType), null));
+      String contentType = contentTypeOpt.isPresent() ? contentTypeOpt.get().stringValue()
+        : "application/json";
+
+      Optional<Literal> subprotocolOpt = Models.objectLiteral(model.filter(formId,
+        rdf.createIRI(HCTL.forSubProtocol), null));
+
+      Set<IRI> opsIRIs = Models.objectIRIs(model.filter(formId, rdf.createIRI(HCTL.hasOperationType),
+        null));
       Set<String> ops = opsIRIs.stream().map(op -> op.stringValue()).collect(Collectors.toSet());
-      
+
       String target = targetOpt.get().stringValue();
-      
+
       Form.Builder builder = new Form.Builder(target)
-          .setContentType(contentType)
-          .addOperationTypes(ops); 
-      
+        .setContentType(contentType)
+        .addOperationTypes(ops);
+
       if (methodNameOpt.isPresent()) {
         builder.setMethodName(methodNameOpt.get().stringValue());
       }
-      
+
       if (subprotocolOpt.isPresent()) {
         builder.addSubProtocol(subprotocolOpt.get().stringValue());
       }
-      
+
       forms.add(builder.build());
     }
-    
+
     if (forms.isEmpty()) {
       throw new InvalidTDException("[" + affordanceType + "] All interaction affordances should have "
-          + "at least one valid.");
+        + "at least one valid.");
     }
-    
+
     return forms;
   }
 }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriter.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriter.java
@@ -1,19 +1,5 @@
 package ch.unisg.ics.interactions.wot.td.io;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.eclipse.rdf4j.model.BNode;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.util.ModelBuilder;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.rio.RDFFormat;
-
 import ch.unisg.ics.interactions.wot.td.ThingDescription;
 import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
 import ch.unisg.ics.interactions.wot.td.affordances.Form;
@@ -25,34 +11,41 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.DCT;
 import ch.unisg.ics.interactions.wot.td.vocabularies.HCTL;
 import ch.unisg.ics.interactions.wot.td.vocabularies.HTV;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.rio.RDFFormat;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A writer for serializing TDs as RDF graphs. Provides a fluent API for adding prefix bindings to be
  * used in the serialization.
- * 
  */
 public class TDGraphWriter {
   private final Resource thingId;
   private final ThingDescription td;
   private final ModelBuilder graphBuilder;
   private final ValueFactory rdf = SimpleValueFactory.getInstance();
-  
+
   public TDGraphWriter(ThingDescription td) {
     this.thingId = td.getThingURI().isPresent() ? rdf.createIRI(td.getThingURI().get())
-        : rdf.createBNode();
-    
+      : rdf.createBNode();
+
     this.td = td;
     this.graphBuilder = new ModelBuilder();
   }
-  
+
   public static String write(ThingDescription td) {
     return new TDGraphWriter(td).write();
   }
-  
+
   /**
    * Sets a prefix binding for a given namespace.
-   * 
-   * @param prefix the prefix to be used in the serialized representation
+   *
+   * @param prefix    the prefix to be used in the serialized representation
    * @param namespace the given namespace
    * @return this <code>TDGraphWriter</code>
    */
@@ -60,148 +53,144 @@ public class TDGraphWriter {
     this.graphBuilder.setNamespace(prefix, namespace);
     return this;
   }
-  
+
   public String write() {
     return this.addTypes()
-        .addTitle()
-        .addSecurity()
-        .addBaseURI()
-        .addProperties()
-        .addActions()
-        .addGraph()
-        .write(RDFFormat.TURTLE);
+      .addTitle()
+      .addSecurity()
+      .addBaseURI()
+      .addProperties()
+      .addActions()
+      .addGraph()
+      .write(RDFFormat.TURTLE);
   }
-  
+
   private Model getModel() {
     return graphBuilder.build();
   }
-  
+
   private TDGraphWriter addSecurity() {
     List<SecurityScheme> securitySchemes = td.getSecuritySchemes();
-    
+
     for (SecurityScheme scheme : securitySchemes) {
       BNode schemeId = rdf.createBNode();
       graphBuilder.add(thingId, rdf.createIRI(TD.hasSecurityConfiguration), schemeId);
-      
+
       Model schemeGraph = scheme.toRDF(schemeId);
       for (Statement s : schemeGraph) {
         graphBuilder.add(s.getSubject(), s.getPredicate(), s.getObject());
       }
     }
-    
+
     return this;
   }
-  
+
   private TDGraphWriter addTypes() {
     graphBuilder.add(thingId, RDF.TYPE, rdf.createIRI(TD.Thing));
-    
+
     for (String type : td.getSemanticTypes()) {
       graphBuilder.add(thingId, RDF.TYPE, rdf.createIRI(type));
     }
-    
+
     return this;
   }
-  
+
   private TDGraphWriter addTitle() {
     graphBuilder.add(thingId, rdf.createIRI(DCT.title), td.getTitle());
     return this;
   }
-    
+
   private TDGraphWriter addBaseURI() {
     if (td.getBaseURI().isPresent()) {
-      graphBuilder.add(thingId, rdf.createIRI(TD.hasBase), 
-          rdf.createIRI(td.getBaseURI().get()));
+      graphBuilder.add(thingId, rdf.createIRI(TD.hasBase),
+        rdf.createIRI(td.getBaseURI().get()));
     }
-    
+
     return this;
   }
-  
+
   private TDGraphWriter addProperties() {
     for (PropertyAffordance property : td.getProperties()) {
       Resource propertyId = addAffordance(property, TD.hasPropertyAffordance, TD.PropertyAffordance);
       graphBuilder.add(propertyId, rdf.createIRI(TD.isObservable), property.isObservable());
-      
+
       SchemaGraphWriter.write(graphBuilder, propertyId, property.getDataSchema());
     }
-    
+
     return this;
   }
-  
+
   private TDGraphWriter addActions() {
     for (ActionAffordance action : td.getActions()) {
       Resource actionId = addAffordance(action, TD.hasActionAffordance, TD.ActionAffordance);
-      
+
       if (action.getInputSchema().isPresent()) {
         DataSchema schema = action.getInputSchema().get();
-        
+
         Resource inputId = rdf.createBNode();
         graphBuilder.add(actionId, rdf.createIRI(TD.hasInputSchema), inputId);
-        
+
         SchemaGraphWriter.write(graphBuilder, inputId, schema);
       }
-      
+
       if (action.getOutputSchema().isPresent()) {
         DataSchema schema = action.getOutputSchema().get();
-        
+
         Resource outputId = rdf.createBNode();
         graphBuilder.add(actionId, rdf.createIRI(TD.hasOutputSchema), outputId);
-        
+
         SchemaGraphWriter.write(graphBuilder, outputId, schema);
       }
     }
-    
+
     return this;
   }
-  
+
   private TDGraphWriter addGraph() {
-  	if(td.getGraph().isPresent()) {
-  		getModel().addAll(td.getGraph().get());
-  		
-  		td.getGraph().get().getNamespaces().stream()
-  		    .filter(ns -> !getModel().getNamespace(ns.getPrefix()).isPresent())
-          .forEach(graphBuilder::setNamespace);
-  	}
-  	return this;
+    if (td.getGraph().isPresent()) {
+      getModel().addAll(td.getGraph().get());
+
+      td.getGraph().get().getNamespaces().stream()
+        .filter(ns -> !getModel().getNamespace(ns.getPrefix()).isPresent())
+        .forEach(graphBuilder::setNamespace);
+    }
+    return this;
   }
-  
-  private Resource addAffordance(InteractionAffordance affordance, String affordanceProp, 
-      String affordanceClass) {
+
+  private Resource addAffordance(InteractionAffordance affordance, String affordanceProp,
+                                 String affordanceClass) {
     BNode affordanceId = rdf.createBNode();
-    
+
     graphBuilder.add(thingId, rdf.createIRI(affordanceProp), affordanceId);
     graphBuilder.add(affordanceId, RDF.TYPE, rdf.createIRI(affordanceClass));
-    
+    graphBuilder.add(affordanceId, rdf.createIRI(TD.name), rdf.createLiteral(affordance.getName()));
+
     for (String type : affordance.getSemanticTypes()) {
       graphBuilder.add(affordanceId, RDF.TYPE, rdf.createIRI(type));
     }
-    
-    if (affordance.getName().isPresent()) {
-      graphBuilder.add(affordanceId, rdf.createIRI(TD.name), 
-          rdf.createLiteral(affordance.getName().get()));
-    }
-    
+
     if (affordance.getTitle().isPresent()) {
       graphBuilder.add(affordanceId, rdf.createIRI(DCT.title), affordance.getTitle().get());
     }
-    
+
     addFormsForInteraction(affordanceId, affordance);
-    
+
     return affordanceId;
   }
-    
+
   private void addFormsForInteraction(Resource interactionId, InteractionAffordance interaction) {
     for (Form form : interaction.getForms()) {
       BNode formId = rdf.createBNode();
-      
+
       graphBuilder.add(interactionId, rdf.createIRI(TD.hasForm), formId);
-      
-      // Only writes the method name for forms with one operation type (to avoid ambiguity)  
+
+      // Only writes the method name for forms with one operation type (to avoid ambiguity)
       if (form.getMethodName().isPresent() && form.getOperationTypes().size() == 1) {
         graphBuilder.add(formId, rdf.createIRI(HTV.methodName), form.getMethodName().get());
       }
       graphBuilder.add(formId, rdf.createIRI(HCTL.hasTarget), rdf.createIRI(form.getTarget()));
       graphBuilder.add(formId, rdf.createIRI(HCTL.forContentType), form.getContentType());
-      
+
       for (String opType : form.getOperationTypes()) {
         try {
           IRI opTypeIri = rdf.createIRI(opType);
@@ -210,14 +199,14 @@ public class TDGraphWriter {
           graphBuilder.add(formId, rdf.createIRI(HCTL.hasOperationType), opType);
         }
       }
-      
+
       Optional<String> subprotocol = form.getSubProtocol();
       if (subprotocol.isPresent()) {
         graphBuilder.add(formId, rdf.createIRI(HCTL.forSubProtocol), subprotocol.get());
       }
     }
   }
-  
+
   private String write(RDFFormat format) {
     return ReadWriteUtils.writeToString(format, getModel());
   }

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/ThingDescriptionTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/ThingDescriptionTest.java
@@ -1,20 +1,17 @@
 package ch.unisg.ics.interactions.wot.td;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.Optional;
-
-import ch.unisg.ics.interactions.wot.td.affordances.InteractionAffordance;
 import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
-import org.junit.Test;
-
 import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme;
 import ch.unisg.ics.interactions.wot.td.security.NoSecurityScheme;
 import ch.unisg.ics.interactions.wot.td.security.SecurityScheme;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 import ch.unisg.ics.interactions.wot.td.vocabularies.WoTSec;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ThingDescriptionTest {
 
@@ -33,8 +30,8 @@ public class ThingDescriptionTest {
   @Test
   public void testURI() {
     ThingDescription td = new ThingDescription.Builder("My Thing")
-        .addThingURI("http://example.org/#thing")
-        .build();
+      .addThingURI("http://example.org/#thing")
+      .build();
 
     assertEquals("http://example.org/#thing", td.getThingURI().get());
   }
@@ -42,8 +39,8 @@ public class ThingDescriptionTest {
   @Test
   public void testOneType() {
     ThingDescription td = new ThingDescription.Builder("My Thing")
-        .addSemanticType("http://w3id.org/eve#Artifact")
-        .build();
+      .addSemanticType("http://w3id.org/eve#Artifact")
+      .build();
 
     assertEquals(1, td.getSemanticTypes().size());
     assertTrue(td.getSemanticTypes().contains("http://w3id.org/eve#Artifact"));
@@ -52,10 +49,10 @@ public class ThingDescriptionTest {
   @Test
   public void testMultipleTypes() {
     ThingDescription td = new ThingDescription.Builder("My Thing")
-        .addSemanticType(TD.Thing)
-        .addSemanticType("http://w3id.org/eve#Artifact")
-        .addSemanticType("http://iot-schema.org/eve#Light")
-        .build();
+      .addSemanticType(TD.Thing)
+      .addSemanticType("http://w3id.org/eve#Artifact")
+      .addSemanticType("http://iot-schema.org/eve#Light")
+      .build();
 
     assertEquals(3, td.getSemanticTypes().size());
     assertTrue(td.getSemanticTypes().contains(TD.Thing));
@@ -66,18 +63,18 @@ public class ThingDescriptionTest {
   @Test
   public void testBaseURI() {
     ThingDescription td = new ThingDescription.Builder("My Thing")
-        .addThingURI("http://example.org/#thing")
-        .addBaseURI("http://example.org/")
-        .build();
+      .addThingURI("http://example.org/#thing")
+      .addBaseURI("http://example.org/")
+      .build();
 
     assertEquals("http://example.org/", td.getBaseURI().get());
   }
 
   public void testGetFirstSecuritySchemeByType() {
     ThingDescription td = new ThingDescription.Builder("Secured Thing")
-        .addSecurityScheme(new NoSecurityScheme())
-        .addSecurityScheme(new APIKeySecurityScheme())
-        .build();
+      .addSecurityScheme(new NoSecurityScheme())
+      .addSecurityScheme(new APIKeySecurityScheme())
+      .build();
 
     Optional<SecurityScheme> scheme = td.getFirstSecuritySchemeByType(WoTSec.APIKeySecurityScheme);
     assertTrue(scheme.isPresent());

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/ThingDescriptionTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/ThingDescriptionTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import ch.unisg.ics.interactions.wot.td.affordances.InteractionAffordance;
+import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
 import org.junit.Test;
 
 import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme;
@@ -24,7 +25,7 @@ public class ThingDescriptionTest {
     assertEquals("My Thing", td.getTitle());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = InvalidTDException.class)
   public void testTitleNull() {
     new ThingDescription.Builder(null).build();
   }

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/ThingDescriptionTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/ThingDescriptionTest.java
@@ -3,8 +3,10 @@ package ch.unisg.ics.interactions.wot.td;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.Optional;
 
+import ch.unisg.ics.interactions.wot.td.affordances.InteractionAffordance;
 import org.junit.Test;
 
 import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme;
@@ -14,33 +16,38 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 import ch.unisg.ics.interactions.wot.td.vocabularies.WoTSec;
 
 public class ThingDescriptionTest {
-  
+
   @Test
   public void testTitle() {
     ThingDescription td = new ThingDescription.Builder("My Thing").build();
-    
+
     assertEquals("My Thing", td.getTitle());
   }
-  
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTitleNull() {
+    new ThingDescription.Builder(null).build();
+  }
+
   @Test
   public void testURI() {
     ThingDescription td = new ThingDescription.Builder("My Thing")
         .addThingURI("http://example.org/#thing")
         .build();
-    
+
     assertEquals("http://example.org/#thing", td.getThingURI().get());
   }
-  
+
   @Test
   public void testOneType() {
     ThingDescription td = new ThingDescription.Builder("My Thing")
         .addSemanticType("http://w3id.org/eve#Artifact")
         .build();
-    
+
     assertEquals(1, td.getSemanticTypes().size());
     assertTrue(td.getSemanticTypes().contains("http://w3id.org/eve#Artifact"));
   }
-  
+
   @Test
   public void testMultipleTypes() {
     ThingDescription td = new ThingDescription.Builder("My Thing")
@@ -48,29 +55,29 @@ public class ThingDescriptionTest {
         .addSemanticType("http://w3id.org/eve#Artifact")
         .addSemanticType("http://iot-schema.org/eve#Light")
         .build();
-    
+
     assertEquals(3, td.getSemanticTypes().size());
     assertTrue(td.getSemanticTypes().contains(TD.Thing));
     assertTrue(td.getSemanticTypes().contains("http://w3id.org/eve#Artifact"));
     assertTrue(td.getSemanticTypes().contains("http://iot-schema.org/eve#Light"));
   }
-  
+
   @Test
   public void testBaseURI() {
     ThingDescription td = new ThingDescription.Builder("My Thing")
         .addThingURI("http://example.org/#thing")
         .addBaseURI("http://example.org/")
         .build();
-    
+
     assertEquals("http://example.org/", td.getBaseURI().get());
   }
-  
+
   public void testGetFirstSecuritySchemeByType() {
     ThingDescription td = new ThingDescription.Builder("Secured Thing")
         .addSecurityScheme(new NoSecurityScheme())
         .addSecurityScheme(new APIKeySecurityScheme())
         .build();
-    
+
     Optional<SecurityScheme> scheme = td.getFirstSecuritySchemeByType(WoTSec.APIKeySecurityScheme);
     assertTrue(scheme.isPresent());
     assertEquals(WoTSec.APIKeySecurityScheme, scheme.get().getSchemeType());

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/ActionAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/ActionAffordanceTest.java
@@ -1,26 +1,25 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ActionAffordanceTest {
-  
+
   private ActionAffordance testAction;
   private Form form;
-  
+
   @Before
   public void init() {
     form = new Form.Builder("http://example.org/action").build();
-    testAction = new ActionAffordance.Builder(form).build();
+    testAction = new ActionAffordance.Builder("an_action", form).build();
   }
 
   @Test
@@ -29,55 +28,54 @@ public class ActionAffordanceTest {
     assertEquals(1, forms.size());
     assertEquals(form, forms.get(0));
   }
-  
+
   @Test
   public void testMultipleForms() {
     Form form1 = new Form.Builder("http://example.org")
-        .setMethodName("GET")
-        .setContentType("application/json")
-        .build();
-    
+      .setMethodName("GET")
+      .setContentType("application/json")
+      .build();
+
     Form form2 = new Form.Builder("http://example.org")
-        .setMethodName("POST")
-        .setContentType("application/json")
-        .build();
-    
+      .setMethodName("POST")
+      .setContentType("application/json")
+      .build();
+
     Form form3 = new Form.Builder("http://example.org")
-        .setMethodName("PUT")
-        .setContentType("application/json")
-        .build();
-    
+      .setMethodName("PUT")
+      .setContentType("application/json")
+      .build();
+
     List<Form> formList = new ArrayList<Form>(Arrays.asList(form1, form2, form3));
-    
-    ActionAffordance action = new ActionAffordance.Builder(formList).build();
+
+    ActionAffordance action = new ActionAffordance.Builder("name", formList).build();
     List<Form> forms = action.getForms();
-    
+
     assertEquals(3, forms.size());
     assertEquals(form1, forms.get(0));
     assertEquals(form2, forms.get(1));
     assertEquals(form3, forms.get(2));
   }
-  
+
   @Test
   public void testDefaultValues() {
     String invokeAction = TD.invokeAction;
     assertTrue(testAction.hasFormWithOperationType(invokeAction));
     assertEquals("POST", testAction.getForms().get(0).getMethodName(invokeAction).get());
   }
-  
+
   @Test
   public void testFullOptionAction() {
     Form form = new Form.Builder("http://example.org").setMethodName("GET").build();
-    
-    ActionAffordance action = new ActionAffordance.Builder(form)
-        .addName("turn_on")
-        .addTitle("Turn on")
-        .addSemanticType("iot:TurnOn")
-        // TODO: add schema as well
-        //.addInputSchema(inputSchema)
-        .build();
-    
-    assertEquals("turn_on", action.getName().get());
+
+    ActionAffordance action = new ActionAffordance.Builder("turn_on", form)
+      .addTitle("Turn on")
+      .addSemanticType("iot:TurnOn")
+      // TODO: add schema as well
+      //.addInputSchema(inputSchema)
+      .build();
+
+    assertEquals("turn_on", action.getName());
     assertEquals("Turn on", action.getTitle().get());
     assertEquals(1, action.getSemanticTypes().size());
     assertEquals("iot:TurnOn", action.getSemanticTypes().get(0));

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Optional;
 
+import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,73 +15,79 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 public class InteractionAffordanceTest {
   private static final String prefix = "http://example.org";
   private InteractionAffordance test_affordance;
-  
+
   @Before
   public void init() {
     Form form1 = new Form.Builder("http://example.org/property1")
         .addOperationType(TD.readProperty)
         .build();
-    
+
     Form form2 = new Form.Builder("http://example.org/property2")
         .addOperationType(TD.writeProperty)
         .build();
-    
-    test_affordance = new InteractionAffordance(Optional.of("my_affordance"), 
-        Optional.of("My Affordance"), Arrays.asList(prefix + "Type1", prefix + "Type2"), 
+
+    test_affordance = new InteractionAffordance(Optional.of("my_affordance"),
+        Optional.of("My Affordance"), Arrays.asList(prefix + "Type1", prefix + "Type2"),
         Arrays.asList(form1, form2));
   }
-  
+
+  @Test(expected = InvalidTDException.class)
+  public void testAffordanceWithoutNameThrowsException() {
+    test_affordance = new InteractionAffordance(Optional.empty(),
+      Optional.of("My Affordance"), Arrays.asList(prefix + "Type1", prefix + "Type2"), null);
+  }
+
   @Test
   public void testHasFormForOperationType() {
     assertTrue(test_affordance.hasFormWithOperationType(TD.readProperty));
     assertTrue(test_affordance.hasFormWithOperationType(TD.writeProperty));
   }
-  
+
   @Test
   public void testNoFormByOperationType() {
     assertFalse(test_affordance.hasFormWithOperationType("bla"));
   }
-  
+
   @Test
   public void testHasSemanticType() {
     assertTrue(test_affordance.hasSemanticType(prefix + "Type1"));
   }
-  
+
   @Test
   public void testHasNotSemanticType() {
     assertFalse(test_affordance.hasSemanticType(prefix + "Type0"));
   }
-  
+
   @Test
   public void testHasOneSemanticType() {
-    assertTrue(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type0", 
+    assertTrue(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type0",
         prefix + "Type1")));
   }
-  
+
   @Test
   public void testHasNotOneSemanticType() {
-    assertFalse(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type3", 
+    assertFalse(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type3",
         prefix + "Type4")));
   }
-  
+
   @Test
   public void testHasAllSemanticTypes() {
-    assertTrue(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1", 
+    assertTrue(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1",
         prefix + "Type2")));
   }
-  
+
   @Test
   public void testHasNotAllSemanticTypes() {
-    assertFalse(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1", 
+    assertFalse(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1",
         prefix + "Type2", prefix + "Type3")));
   }
-  
+
   @Test
   public void testGetFirstFormForOperationType() {
     assertTrue(test_affordance.getFirstFormForOperationType(TD.readProperty)
         .isPresent());
   }
-  
+
   @Test
   public void testNoFirstFormForOperationType() {
     assertFalse(test_affordance.getFirstFormForOperationType(TD.invokeAction)

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
@@ -1,16 +1,14 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Optional;
 
-import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
-import org.junit.Before;
-import org.junit.Test;
-
-import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class InteractionAffordanceTest {
   private static final String prefix = "http://example.org";
@@ -19,21 +17,21 @@ public class InteractionAffordanceTest {
   @Before
   public void init() {
     Form form1 = new Form.Builder("http://example.org/property1")
-        .addOperationType(TD.readProperty)
-        .build();
+      .addOperationType(TD.readProperty)
+      .build();
 
     Form form2 = new Form.Builder("http://example.org/property2")
-        .addOperationType(TD.writeProperty)
-        .build();
+      .addOperationType(TD.writeProperty)
+      .build();
 
-    test_affordance = new InteractionAffordance(Optional.of("my_affordance"),
-        Optional.of("My Affordance"), Arrays.asList(prefix + "Type1", prefix + "Type2"),
-        Arrays.asList(form1, form2));
+    test_affordance = new InteractionAffordance("my_affordance",
+      Optional.of("My Affordance"), Arrays.asList(prefix + "Type1", prefix + "Type2"),
+      Arrays.asList(form1, form2));
   }
 
-  @Test(expected = InvalidTDException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testAffordanceWithoutNameThrowsException() {
-    test_affordance = new InteractionAffordance(Optional.empty(),
+    new InteractionAffordance(null,
       Optional.of("My Affordance"), Arrays.asList(prefix + "Type1", prefix + "Type2"), null);
   }
 
@@ -61,36 +59,36 @@ public class InteractionAffordanceTest {
   @Test
   public void testHasOneSemanticType() {
     assertTrue(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type0",
-        prefix + "Type1")));
+      prefix + "Type1")));
   }
 
   @Test
   public void testHasNotOneSemanticType() {
     assertFalse(test_affordance.hasOneSemanticType(Arrays.asList(prefix + "Type3",
-        prefix + "Type4")));
+      prefix + "Type4")));
   }
 
   @Test
   public void testHasAllSemanticTypes() {
     assertTrue(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1",
-        prefix + "Type2")));
+      prefix + "Type2")));
   }
 
   @Test
   public void testHasNotAllSemanticTypes() {
     assertFalse(test_affordance.hasAllSemanticTypes(Arrays.asList(prefix + "Type1",
-        prefix + "Type2", prefix + "Type3")));
+      prefix + "Type2", prefix + "Type3")));
   }
 
   @Test
   public void testGetFirstFormForOperationType() {
     assertTrue(test_affordance.getFirstFormForOperationType(TD.readProperty)
-        .isPresent());
+      .isPresent());
   }
 
   @Test
   public void testNoFirstFormForOperationType() {
     assertFalse(test_affordance.getFirstFormForOperationType(TD.invokeAction)
-        .isPresent());
+      .isPresent());
   }
 }

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
@@ -1,5 +1,6 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
+import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +30,7 @@ public class InteractionAffordanceTest {
       Arrays.asList(form1, form2));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = InvalidTDException.class)
   public void testAffordanceWithoutNameThrowsException() {
     new InteractionAffordance(null,
       Optional.of("My Affordance"), Arrays.asList(prefix + "Type1", prefix + "Type2"), null);

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/PropertyAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/PropertyAffordanceTest.java
@@ -1,32 +1,31 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import ch.unisg.ics.interactions.wot.td.schemas.DataSchema;
 import ch.unisg.ics.interactions.wot.td.schemas.NumberSchema;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PropertyAffordanceTest {
 
   private PropertyAffordance testProperty;
-  
+
   @Before
   public void init() {
     DataSchema schema = new NumberSchema.Builder().build();
     Form form = new Form.Builder("http://example.org/action1")
-        .build();
-    
-    testProperty = new PropertyAffordance.Builder(schema, form)
-        .addTitle("My Property")
-        .addSemanticType("sem_type")
-        .addObserve()
-        .build();
+      .build();
+
+    testProperty = new PropertyAffordance.Builder("my_property", schema, form)
+      .addTitle("My Property")
+      .addSemanticType("sem_type")
+      .addObserve()
+      .build();
   }
-  
+
   @Test
   public void testProperty() {
     assertEquals("My Property", testProperty.getTitle().get());
@@ -35,12 +34,12 @@ public class PropertyAffordanceTest {
     assertEquals(1, testProperty.getForms().size());
     assertTrue(testProperty.isObservable());
   }
-  
+
   @Test
   public void testDefaultOperationTypes() {
     assertTrue(testProperty.hasFormWithOperationType(TD.readProperty));
     assertTrue(testProperty.hasFormWithOperationType(TD.writeProperty));
-    
+
     Form form = testProperty.getForms().get(0);
     assertEquals("GET", form.getMethodName(TD.readProperty).get());
     assertEquals("PUT", form.getMethodName(TD.writeProperty).get());

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/clients/TDHttpRequestTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/clients/TDHttpRequestTest.java
@@ -46,7 +46,7 @@ import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 
 public class TDHttpRequestTest {
   private static final String PREFIX = "http://example.org/";
-  
+
   static final ObjectSchema USER_SCHEMA = new ObjectSchema.Builder()
       .addSemanticType(PREFIX + "User")
       .addProperty("first_name", new StringSchema.Builder()
@@ -57,76 +57,78 @@ public class TDHttpRequestTest {
           .build())
       .addRequiredProperties("last_name")
       .build();
-  
+
   private static final Form FORM = new Form.Builder(PREFIX + "toggle")
       .setMethodName("PUT")
       .addOperationType(TD.invokeAction)
       .build();
-  
-  private static final String FORKLIFT_ROBOT_TD = "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" + 
-      "@prefix htv: <http://www.w3.org/2011/http#> .\n" + 
-      "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" + 
-      "@prefix dct: <http://purl.org/dc/terms/> .\n" + 
-      "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" + 
-      "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" + 
-      "@prefix ex: <http://example.org/> .\n" + 
-      "\n" + 
-      "ex:forkliftRobot a td:Thing ; \n" + 
-      "    dct:title \"forkliftRobot\" ;\n" + 
-      "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" + 
-      "    td:hasPropertyAffordance [\n" + 
-      "        a td:PropertyAffordance, js:BooleanSchema, ex:Status ; \n" + 
-      "        td:hasForm [\n" + 
-      "            hctl:hasTarget <http://example.org/forkliftRobot/busy> ; \n" + 
-      "        ] ; \n" + 
-      "    ] ;\n" + 
-      "    td:hasActionAffordance [\n" + 
-      "        a td:ActionAffordance, ex:CarryFromTo ;\n" + 
-      "        dct:title \"carry\" ; \n" + 
-      "        td:hasForm [\n" + 
-      "            hctl:hasTarget <http://example.org/forkliftRobot/carry> ; \n" + 
-      "        ] ; \n" + 
-      "        td:hasInputSchema [ \n" + 
-      "            a js:ObjectSchema ;\n" + 
-      "            js:properties [ \n" + 
-      "                a js:ArraySchema, ex:SourcePosition ;\n" + 
-      "                js:propertyName \"sourcePosition\";\n" + 
-      "                js:minItems 3 ;\n" + 
-      "                js:maxItems 3 ;\n" + 
-      "                js:items [\n" + 
-      "                    a js:NumberSchema ;\n" + 
-      "                ] ;\n" + 
-      "            ] ;\n" + 
-      "            js:properties [\n" + 
-      "                a js:ArraySchema, ex:TargetPosition ;\n" + 
-      "                js:propertyName \"targetPosition\";\n" + 
-      "                js:minItems 3 ;\n" + 
-      "                js:maxItems 3 ;\n" + 
-      "                js:items [\n" + 
-      "                    a js:NumberSchema ;\n" + 
-      "                ] ;\n" + 
-      "            ] ;\n" + 
+
+  private static final String FORKLIFT_ROBOT_TD = "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+      "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
+      "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" +
+      "@prefix dct: <http://purl.org/dc/terms/> .\n" +
+      "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
+      "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
+      "@prefix ex: <http://example.org/> .\n" +
+      "\n" +
+      "ex:forkliftRobot a td:Thing ; \n" +
+      "    dct:title \"forkliftRobot\" ;\n" +
+      "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
+      "    td:hasPropertyAffordance [\n" +
+      "        a td:PropertyAffordance, js:BooleanSchema, ex:Status ; \n" +
+      "        td:name \"status\" ; \n" +
+      "        td:hasForm [\n" +
+      "            hctl:hasTarget <http://example.org/forkliftRobot/busy> ; \n" +
+      "        ] ; \n" +
+      "    ] ;\n" +
+      "    td:hasActionAffordance [\n" +
+      "        a td:ActionAffordance, ex:CarryFromTo ;\n" +
+      "        dct:title \"carry\" ; \n" +
+      "        td:name \"carry\" ; \n" +
+      "        td:hasForm [\n" +
+      "            hctl:hasTarget <http://example.org/forkliftRobot/carry> ; \n" +
+      "        ] ; \n" +
+      "        td:hasInputSchema [ \n" +
+      "            a js:ObjectSchema ;\n" +
+      "            js:properties [ \n" +
+      "                a js:ArraySchema, ex:SourcePosition ;\n" +
+      "                js:propertyName \"sourcePosition\";\n" +
+      "                js:minItems 3 ;\n" +
+      "                js:maxItems 3 ;\n" +
+      "                js:items [\n" +
+      "                    a js:NumberSchema ;\n" +
+      "                ] ;\n" +
+      "            ] ;\n" +
+      "            js:properties [\n" +
+      "                a js:ArraySchema, ex:TargetPosition ;\n" +
+      "                js:propertyName \"targetPosition\";\n" +
+      "                js:minItems 3 ;\n" +
+      "                js:maxItems 3 ;\n" +
+      "                js:items [\n" +
+      "                    a js:NumberSchema ;\n" +
+      "                ] ;\n" +
+      "            ] ;\n" +
       "            js:required \"sourcePosition\", \"targetPosition\" ;" +
-      "        ] ; \n" + 
+      "        ] ; \n" +
       "    ] .\n";
-  
+
   private ThingDescription td;
-  
+
   @Before
   public void init() {
     td = TDGraphReader.readFromString(TDFormat.RDF_TURTLE, FORKLIFT_ROBOT_TD);
   }
-  
+
   @Test
   public void testToStringNullEntity() {
     TDHttpRequest request = new TDHttpRequest(new Form.Builder("http://example.org/action")
-        .addOperationType(TD.invokeAction).build(), 
+        .addOperationType(TD.invokeAction).build(),
         TD.invokeAction);
-    
+
     assertEquals("[TDHttpRequest] Method: POST, Target: http://example.org/action, "
         + "Content-Type: application/json", request.toString());
   }
-  
+
   @Test
   public void testWriteProperty() throws UnsupportedOperationException, IOException {
     assertEquals(1, td.getProperties().size());
@@ -134,143 +136,143 @@ public class TDHttpRequestTest {
     assertTrue(property.isPresent());
     Optional<Form> form = property.get().getFirstFormForOperationType(TD.writeProperty);
     assertTrue(form.isPresent());
-    
+
     BasicClassicHttpRequest request = new TDHttpRequest(form.get(), TD.writeProperty)
         .setPrimitivePayload(property.get().getDataSchema(), true)
         .getRequest();
-    
+
     assertEquals("PUT", request.getMethod());
-    
+
     StringWriter writer = new StringWriter();
     IOUtils.copy(request.getEntity().getContent(), writer, StandardCharsets.UTF_8.name());
     JsonElement payload = JsonParser.parseString(writer.toString());
-    
+
     assertTrue(payload.isJsonPrimitive());
     assertTrue(payload.getAsBoolean());
   }
-  
+
   @Test
   public void testInvokeAction() throws UnsupportedOperationException, IOException {
     Optional<ActionAffordance> action = td.getFirstActionBySemanticType(PREFIX + "CarryFromTo");
     assertTrue(action.isPresent());
     Optional<Form> form = action.get().getFirstForm();
     assertTrue(form.isPresent());
-    
+
     Map<String, Object> payloadVariables = new HashMap<String, Object>();
     payloadVariables.put(PREFIX + "SourcePosition", Arrays.asList(30, 50, 70));
     payloadVariables.put(PREFIX + "TargetPosition", Arrays.asList(30, 60, 70));
-    
+
     BasicClassicHttpRequest request = new TDHttpRequest(form.get(), TD.invokeAction)
         .setObjectPayload((ObjectSchema) action.get().getInputSchema().get(), payloadVariables)
         .getRequest();
-    
+
     assertEquals("POST", request.getMethod());
-    
+
     StringWriter writer = new StringWriter();
     IOUtils.copy(request.getEntity().getContent(), writer, StandardCharsets.UTF_8.name());
     JsonObject payload = JsonParser.parseString(writer.toString()).getAsJsonObject();
-    
+
     JsonArray sourcePosition = payload.get("sourcePosition").getAsJsonArray();
     assertEquals(30, sourcePosition.get(0).getAsInt());
     assertEquals(50, sourcePosition.get(1).getAsInt());
     assertEquals(70, sourcePosition.get(2).getAsInt());
-    
+
     JsonArray targetPosition = payload.get("targetPosition").getAsJsonArray();
     assertEquals(30, targetPosition.get(0).getAsInt());
     assertEquals(60, targetPosition.get(1).getAsInt());
     assertEquals(70, targetPosition.get(2).getAsInt());
   }
-  
+
   @Test
   public void testNoPayload() {
     BasicClassicHttpRequest request = new TDHttpRequest(FORM, TD.invokeAction)
         .getRequest();
     assertNull(request.getEntity());
   }
-  
+
   @Test
-  public void testSimpleObjectPayload() throws ProtocolException, URISyntaxException, 
+  public void testSimpleObjectPayload() throws ProtocolException, URISyntaxException,
       JsonSyntaxException, ParseException, IOException {
     ObjectSchema payloadSchema = new ObjectSchema.Builder()
         .addProperty("first_name", new StringSchema.Builder().build())
         .addProperty("last_name", new StringSchema.Builder().build())
         .build();
-    
+
     Map<String, Object> payloadVariables = new HashMap<String, Object>();
     payloadVariables.put("first_name", "Andrei");
     payloadVariables.put("last_name", "Ciortea");
-    
+
     BasicClassicHttpRequest request = new TDHttpRequest(FORM, TD.invokeAction)
         .setObjectPayload(payloadSchema, payloadVariables)
         .getRequest();
-    
+
     assertUserSchemaPayload(request);
   }
-  
+
   @Test
-  public void testSimpleSemanticObjectPayload() throws ProtocolException, URISyntaxException, 
+  public void testSimpleSemanticObjectPayload() throws ProtocolException, URISyntaxException,
       JsonSyntaxException, ParseException, IOException {
     Map<String, Object> payloadVariables = new HashMap<String, Object>();
     payloadVariables.put(PREFIX + "FirstName", "Andrei");
     payloadVariables.put(PREFIX + "LastName", "Ciortea");
-    
+
     BasicClassicHttpRequest request = new TDHttpRequest(FORM, TD.invokeAction)
         .setObjectPayload(USER_SCHEMA, payloadVariables)
         .getRequest();
-    
+
     assertEquals("PUT", request.getMethod());
     assertEquals(0, request.getUri().compareTo(URI.create(PREFIX + "toggle")));
     assertUserSchemaPayload(request);
   }
-  
+
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidBooleanPayload() {
     new TDHttpRequest(FORM, TD.invokeAction)
     .setPrimitivePayload(new BooleanSchema.Builder().build(), "string")
     .getRequest();
   }
-  
+
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidIntegerPayload() {
     new TDHttpRequest(FORM, TD.invokeAction)
     .setPrimitivePayload(new IntegerSchema.Builder().build(), 0.5)
     .getRequest();
   }
-  
+
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidStringPayload() {
     new TDHttpRequest(FORM, TD.invokeAction)
     .setPrimitivePayload(new StringSchema.Builder().build(), true)
     .getRequest();
   }
-  
+
   @Test
   public void testArrayPayload() throws UnsupportedOperationException, IOException {
     ArraySchema payloadSchema = new ArraySchema.Builder()
         .addItem(new NumberSchema.Builder().build())
         .build();
-    
+
     List<Object> payloadVariables = new ArrayList<Object>();
     payloadVariables.add(1);
     payloadVariables.add(3);
     payloadVariables.add(5);
-    
+
     BasicClassicHttpRequest request = new TDHttpRequest(FORM, TD.invokeAction)
         .setArrayPayload(payloadSchema, payloadVariables)
         .getRequest();
-    
+
     StringWriter writer = new StringWriter();
     IOUtils.copy(request.getEntity().getContent(), writer, StandardCharsets.UTF_8.name());
-    
+
     JsonArray payload = JsonParser.parseString(writer.toString()).getAsJsonArray();
     assertEquals(3, payload.size());
     assertEquals(1, payload.get(0).getAsInt());
     assertEquals(3, payload.get(1).getAsInt());
     assertEquals(5, payload.get(2).getAsInt());
   }
-  
+
   @Test
-  public void testSemanticObjectWithOneArrayPayload() throws UnsupportedOperationException, 
+  public void testSemanticObjectWithOneArrayPayload() throws UnsupportedOperationException,
       IOException {
     ObjectSchema payloadSchema = new ObjectSchema.Builder()
         .addProperty("speed", new NumberSchema.Builder()
@@ -281,55 +283,55 @@ public class TDHttpRequestTest {
             .addItem(new IntegerSchema.Builder().build())
             .build())
         .build();
-    
+
     List<Object> coordinates = new ArrayList<Object>();
     coordinates.add(30);
     coordinates.add(50);
     coordinates.add(70);
-    
+
     Map<String, Object> payloadVariables = new HashMap<String, Object>();
     payloadVariables.put(PREFIX + "Speed", 3.5);
     payloadVariables.put(PREFIX + "3DCoordinates", coordinates);
-    
+
     BasicClassicHttpRequest request = new TDHttpRequest(FORM, TD.invokeAction)
         .setObjectPayload(payloadSchema, payloadVariables)
         .getRequest();
-    
+
     StringWriter writer = new StringWriter();
     IOUtils.copy(request.getEntity().getContent(), writer, StandardCharsets.UTF_8.name());
-    
+
     JsonObject payload = JsonParser.parseString(writer.toString()).getAsJsonObject();
     assertEquals(3.5, payload.get("speed").getAsDouble(), 0.01);
-    
+
     JsonArray coordinatesArray = payload.getAsJsonArray("coordinates");
     assertEquals(3, coordinatesArray.size());
     assertEquals(30, coordinatesArray.get(0).getAsInt());
     assertEquals(50, coordinatesArray.get(1).getAsInt());
     assertEquals(70, coordinatesArray.get(2).getAsInt());
   }
-  
+
   @Test
   public void testArrayOfSemanticObjectsPayload() {
     // TODO
   }
-  
+
   @Test
   public void testSemanticObjectWithArrayOfSemanticObjectsPayload() {
     // TODO
   }
-  
+
   @Test
   public void testValidateArrayPayload() {
     // TODO
   }
-  
-  private void assertUserSchemaPayload(BasicClassicHttpRequest request) 
+
+  private void assertUserSchemaPayload(BasicClassicHttpRequest request)
       throws UnsupportedOperationException, IOException, ProtocolException {
     StringWriter writer = new StringWriter();
     IOUtils.copy(request.getEntity().getContent(), writer, StandardCharsets.UTF_8.name());
-    
+
     assertEquals("application/json", request.getHeader(HttpHeaders.CONTENT_TYPE).getValue());
-    
+
     JsonObject payload = JsonParser.parseString(writer.toString()).getAsJsonObject();
     assertEquals("Andrei", payload.get("first_name").getAsString());
     assertEquals("Ciortea", payload.get("last_name").getAsString());

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReaderTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReaderTest.java
@@ -1,19 +1,5 @@
 package ch.unisg.ics.interactions.wot.td.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.junit.Test;
-
 import ch.unisg.ics.interactions.wot.td.ThingDescription;
 import ch.unisg.ics.interactions.wot.td.ThingDescription.TDFormat;
 import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
@@ -28,536 +14,625 @@ import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme.TokenLocat
 import ch.unisg.ics.interactions.wot.td.security.SecurityScheme;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 import ch.unisg.ics.interactions.wot.td.vocabularies.WoTSec;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
 
 public class TDGraphReaderTest {
-  
+
   private static final String TEST_SIMPLE_TD =
-      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+    "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
       "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
       "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" +
       "@prefix dct: <http://purl.org/dc/terms/> .\n" +
       "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
       "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
       "\n" +
-      "<http://example.org/#thing> a td:Thing ;\n" + 
+      "<http://example.org/#thing> a td:Thing ;\n" +
       "    dct:title \"My Thing\" ;\n" +
       "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
       "    td:hasBase <http://example.org/> ;\n" +
-      "    td:hasPropertyAffordance [\n" + 
+      "    td:hasPropertyAffordance [\n" +
       "        a td:PropertyAffordance, js:NumberSchema ;\n" +
       "        td:name \"my_property\" ;\n" +
       "        dct:title \"My Property\" ;\n" +
       "        td:isObservable true ;\n" +
-      "        td:hasForm [\n" + 
-      "            htv:methodName \"PUT\" ;\n" + 
-      "            hctl:hasTarget <http://example.org/property> ;\n" + 
-      "            hctl:forContentType \"application/json\";\n" + 
+      "        td:hasForm [\n" +
+      "            htv:methodName \"PUT\" ;\n" +
+      "            hctl:hasTarget <http://example.org/property> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
       "            hctl:hasOperationType td:writeProperty;\n" +
-      "        ] ;\n" + 
-      "        td:hasForm [\n" + 
-      "            htv:methodName \"GET\" ;\n" + 
-      "            hctl:hasTarget <http://example.org/property> ;\n" + 
-      "            hctl:forContentType \"application/json\";\n" + 
+      "        ] ;\n" +
+      "        td:hasForm [\n" +
+      "            htv:methodName \"GET\" ;\n" +
+      "            hctl:hasTarget <http://example.org/property> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
       "            hctl:hasOperationType td:readProperty;\n" +
       "            hctl:forSubProtocol \"websub\";\n" +
-      "        ] ;\n" + 
-      "    ] ;\n" + 
-      "    td:hasActionAffordance [\n" + 
-      "        a td:ActionAffordance ;\n" + 
+      "        ] ;\n" +
+      "    ] ;\n" +
+      "    td:hasActionAffordance [\n" +
+      "        a td:ActionAffordance ;\n" +
       "        td:name \"my_action\" ;\n" +
-      "        dct:title \"My Action\" ;\n" + 
-      "        td:hasForm [\n" + 
-      "            htv:methodName \"PUT\" ;\n" + 
-      "            hctl:hasTarget <http://example.org/action> ;\n" + 
-      "            hctl:forContentType \"application/json\";\n" + 
-      "            hctl:hasOperationType td:invokeAction;\n" + 
-      "        ] ;\n" + 
-      "        td:hasInputSchema [\n" + 
-      "            a js:ObjectSchema ;\n" + 
-      "            js:properties [\n" + 
+      "        dct:title \"My Action\" ;\n" +
+      "        td:hasForm [\n" +
+      "            htv:methodName \"PUT\" ;\n" +
+      "            hctl:hasTarget <http://example.org/action> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:invokeAction;\n" +
+      "        ] ;\n" +
+      "        td:hasInputSchema [\n" +
+      "            a js:ObjectSchema ;\n" +
+      "            js:properties [\n" +
       "                a js:NumberSchema ;\n" +
       "                js:propertyName \"number_value\";\n" +
-      "                js:maximum 100.05 ;\n" + 
+      "                js:maximum 100.05 ;\n" +
       "                js:minimum -100.05 ;\n" +
       "            ] ;\n" +
       "            js:required \"number_value\" ;\n" +
-      "        ] ;\n" + 
-      "        td:hasOutputSchema [\n" + 
-      "            a js:ObjectSchema ;\n" + 
-      "            js:properties [\n" + 
+      "        ] ;\n" +
+      "        td:hasOutputSchema [\n" +
+      "            a js:ObjectSchema ;\n" +
+      "            js:properties [\n" +
       "                a js:BooleanSchema ;\n" +
       "                js:propertyName \"boolean_value\";\n" +
       "            ] ;\n" +
       "            js:required \"boolean_value\" ;\n" +
-      "        ]\n" + 
-      "    ] ." ;
-  
-  private static final String TEST_SIMPLE_TD_JSONLD = "[ {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx111\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/security#NoSecurityScheme\" ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx112\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/td#ActionAffordance\" ],\n" + 
-      "  \"http://purl.org/dc/terms/title\" : [ {\n" + 
-      "    \"@value\" : \"My Action\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasForm\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx113\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasInputSchema\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx114\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasOutputSchema\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx116\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx113\",\n" + 
-      "  \"http://www.w3.org/2011/http#methodName\" : [ {\n" + 
-      "    \"@value\" : \"PUT\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/hypermedia#forContentType\" : [ {\n" + 
-      "    \"@value\" : \"application/json\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/hypermedia#hasOperationType\" : [ {\n" + 
-      "    \"@id\" : \"https://www.w3.org/2019/wot/td#invokeAction\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/hypermedia#hasTarget\" : [ {\n" + 
-      "    \"@id\" : \"http://example.org/action\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx114\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#ObjectSchema\" ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#properties\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx115\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#required\" : [ {\n" + 
-      "    \"@value\" : \"number_value\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx115\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#NumberSchema\" ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#maximum\" : [ {\n" + 
-      "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#decimal\",\n" + 
-      "    \"@value\" : \"100.05\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#minimum\" : [ {\n" + 
-      "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#decimal\",\n" + 
-      "    \"@value\" : \"-100.05\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#propertyName\" : [ {\n" + 
-      "    \"@value\" : \"number_value\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx116\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#ObjectSchema\" ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#properties\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx117\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#required\" : [ {\n" + 
-      "    \"@value\" : \"boolean_value\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"_:node1ea75dfphx117\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#BooleanSchema\" ],\n" + 
-      "  \"https://www.w3.org/2019/wot/json-schema#propertyName\" : [ {\n" + 
-      "    \"@value\" : \"boolean_value\"\n" + 
-      "  } ]\n" + 
-      "}, {\n" + 
-      "  \"@id\" : \"http://example.org/#thing\",\n" + 
-      "  \"@type\" : [ \"https://www.w3.org/2019/wot/td#Thing\" ],\n" + 
-      "  \"http://purl.org/dc/terms/title\" : [ {\n" + 
-      "    \"@value\" : \"My Thing\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasActionAffordance\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx112\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasBase\" : [ {\n" + 
-      "    \"@id\" : \"http://example.org/\"\n" + 
-      "  } ],\n" + 
-      "  \"https://www.w3.org/2019/wot/td#hasSecurityConfiguration\" : [ {\n" + 
-      "    \"@id\" : \"_:node1ea75dfphx111\"\n" + 
-      "  } ]\n" + 
-      "} ]";
-  
+      "        ]\n" +
+      "    ] .";
+
+  private static final String TEST_SIMPLE_TD_JSONLD = "[ {\n" +
+    "  \"@id\" : \"_:node1ea75dfphx111\",\n" +
+    "  \"@type\" : [ \"https://www.w3.org/2019/wot/security#NoSecurityScheme\" ]\n" +
+    "}, {\n" +
+    "  \"@id\" : \"_:node1ea75dfphx112\",\n" +
+    "  \"@type\" : [ \"https://www.w3.org/2019/wot/td#ActionAffordance\" ],\n" +
+    "  \"http://purl.org/dc/terms/title\" : [ {\n" +
+    "    \"@value\" : \"My Action\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/td#hasForm\" : [ {\n" +
+    "    \"@id\" : \"_:node1ea75dfphx113\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/td#hasInputSchema\" : [ {\n" +
+    "    \"@id\" : \"_:node1ea75dfphx114\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/td#hasOutputSchema\" : [ {\n" +
+    "    \"@id\" : \"_:node1ea75dfphx116\"\n" +
+    "  } ]\n" +
+    "}, {\n" +
+    "  \"@id\" : \"_:node1ea75dfphx113\",\n" +
+    "  \"http://www.w3.org/2011/http#methodName\" : [ {\n" +
+    "    \"@value\" : \"PUT\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/hypermedia#forContentType\" : [ {\n" +
+    "    \"@value\" : \"application/json\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/hypermedia#hasOperationType\" : [ {\n" +
+    "    \"@id\" : \"https://www.w3.org/2019/wot/td#invokeAction\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/hypermedia#hasTarget\" : [ {\n" +
+    "    \"@id\" : \"http://example.org/action\"\n" +
+    "  } ]\n" +
+    "}, {\n" +
+    "  \"@id\" : \"_:node1ea75dfphx114\",\n" +
+    "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#ObjectSchema\" ],\n" +
+    "  \"https://www.w3.org/2019/wot/json-schema#properties\" : [ {\n" +
+    "    \"@id\" : \"_:node1ea75dfphx115\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/json-schema#required\" : [ {\n" +
+    "    \"@value\" : \"number_value\"\n" +
+    "  } ]\n" +
+    "}, {\n" +
+    "  \"@id\" : \"_:node1ea75dfphx115\",\n" +
+    "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#NumberSchema\" ],\n" +
+    "  \"https://www.w3.org/2019/wot/json-schema#maximum\" : [ {\n" +
+    "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#decimal\",\n" +
+    "    \"@value\" : \"100.05\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/json-schema#minimum\" : [ {\n" +
+    "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#decimal\",\n" +
+    "    \"@value\" : \"-100.05\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/json-schema#propertyName\" : [ {\n" +
+    "    \"@value\" : \"number_value\"\n" +
+    "  } ]\n" +
+    "}, {\n" +
+    "  \"@id\" : \"_:node1ea75dfphx116\",\n" +
+    "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#ObjectSchema\" ],\n" +
+    "  \"https://www.w3.org/2019/wot/json-schema#properties\" : [ {\n" +
+    "    \"@id\" : \"_:node1ea75dfphx117\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/json-schema#required\" : [ {\n" +
+    "    \"@value\" : \"boolean_value\"\n" +
+    "  } ]\n" +
+    "}, {\n" +
+    "  \"@id\" : \"_:node1ea75dfphx117\",\n" +
+    "  \"@type\" : [ \"https://www.w3.org/2019/wot/json-schema#BooleanSchema\" ],\n" +
+    "  \"https://www.w3.org/2019/wot/json-schema#propertyName\" : [ {\n" +
+    "    \"@value\" : \"boolean_value\"\n" +
+    "  } ]\n" +
+    "}, {\n" +
+    "  \"@id\" : \"http://example.org/#thing\",\n" +
+    "  \"@type\" : [ \"https://www.w3.org/2019/wot/td#Thing\" ],\n" +
+    "  \"http://purl.org/dc/terms/title\" : [ {\n" +
+    "    \"@value\" : \"My Thing\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/td#hasActionAffordance\" : [ {\n" +
+    "    \"@id\" : \"_:node1ea75dfphx112\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/td#hasBase\" : [ {\n" +
+    "    \"@id\" : \"http://example.org/\"\n" +
+    "  } ],\n" +
+    "  \"https://www.w3.org/2019/wot/td#hasSecurityConfiguration\" : [ {\n" +
+    "    \"@id\" : \"_:node1ea75dfphx111\"\n" +
+    "  } ]\n" +
+    "} ]";
+
   private static final String TEST_IO_HEAD =
-      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+    "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
       "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
       "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" +
       "@prefix dct: <http://purl.org/dc/terms/> .\n" +
       "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
       "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
       "\n" +
-      "<http://example.org/#thing> a td:Thing ;\n" + 
+      "<http://example.org/#thing> a td:Thing ;\n" +
       "    dct:title \"My Thing\" ;\n" +
       "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-      "    td:hasBase <http://example.org/> ;\n" + 
-      "    td:hasActionAffordance [\n" + 
-      "        a td:ActionAffordance ;\n" + 
-      "        dct:title \"My Action\" ;\n" + 
-      "        td:hasForm [\n" + 
-      "            htv:methodName \"PUT\" ;\n" + 
-      "            hctl:hasTarget <http://example.org/action> ;\n" + 
-      "            hctl:forContentType \"application/json\";\n" + 
-      "            hctl:hasOperationType td:invokeAction;\n" + 
+      "    td:hasBase <http://example.org/> ;\n" +
+      "    td:hasActionAffordance [\n" +
+      "        a td:ActionAffordance ;\n" +
+      "        td:name \"my_action\" ;\n" +
+      "        dct:title \"My Action\" ;\n" +
+      "        td:hasForm [\n" +
+      "            htv:methodName \"PUT\" ;\n" +
+      "            hctl:hasTarget <http://example.org/action> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:invokeAction;\n" +
       "        ] ;\n";
-      
-  private static final String TEST_IO_TAIL = "    ] ." ;
-  
+
+  private static final String TEST_IO_TAIL = "    ] .";
+
   @Test
   public void testReadTitle() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.JSONLD, TEST_SIMPLE_TD_JSONLD);
-    
+
     assertEquals("My Thing", reader.readThingTitle());
   }
-  
+
   @Test
   public void testReadThingTypes() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     assertEquals(1, reader.readThingTypes().size());
     assertTrue(reader.readThingTypes().contains(TD.Thing));
   }
-  
+
   @Test
   public void testReadBaseURI() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     assertEquals("http://example.org/", reader.readBaseURI().get());
   }
-  
+
   @Test
   public void testReadOneSecurityScheme() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     assertEquals(1, reader.readSecuritySchemes().size());
-    
-    assertTrue(reader.readSecuritySchemes().stream().anyMatch(scheme -> 
-        scheme.getSchemeType().equals(WoTSec.NoSecurityScheme)));
+
+    assertTrue(reader.readSecuritySchemes().stream().anyMatch(scheme ->
+      scheme.getSchemeType().equals(WoTSec.NoSecurityScheme)));
   }
-  
+
   @Test
   public void testReadAPIKeySecurityScheme() {
     String testTD =
-        "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ;\n" +
         "        wotsec:in \"header\" ;\n" +
         "        wotsec:name \"X-API-Key\" ;\n" +
         "  ] .";
-    
+
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, testTD);
-    
+
     assertEquals(1, reader.readSecuritySchemes().size());
-    
+
     SecurityScheme scheme = reader.readSecuritySchemes().iterator().next();
     assertTrue(scheme instanceof APIKeySecurityScheme);
-    assertEquals(WoTSec.APIKeySecurityScheme, ((APIKeySecurityScheme) scheme).getSchemeType());
+    assertEquals(WoTSec.APIKeySecurityScheme, scheme.getSchemeType());
     assertEquals(TokenLocation.HEADER, ((APIKeySecurityScheme) scheme).getIn());
     assertEquals("X-API-Key", ((APIKeySecurityScheme) scheme).getName().get());
   }
-  
+
   @Test
   public void testAPIKeySecuritySchemeDefaultValues() {
     String testTD =
-        "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ] .";
-    
+
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, testTD);
     assertEquals(1, reader.readSecuritySchemes().size());
     SecurityScheme scheme = reader.readSecuritySchemes().iterator().next();
-    assertEquals(WoTSec.APIKeySecurityScheme, ((APIKeySecurityScheme) scheme).getSchemeType());
+    assertEquals(WoTSec.APIKeySecurityScheme, scheme.getSchemeType());
     assertEquals(TokenLocation.QUERY, ((APIKeySecurityScheme) scheme).getIn());
     assertFalse(((APIKeySecurityScheme) scheme).getName().isPresent());
   }
-  
+
   @Test(expected = InvalidTDException.class)
   public void testAPIKeySecuritySchemeInvalidTokenLocation() {
     String testTD =
-        "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ;\n" +
         "        wotsec:in \"bla\" ;\n" +
         "  ] .";
-    
+
     new TDGraphReader(RDFFormat.TURTLE, testTD).readSecuritySchemes();
   }
-  
+
   @Test
   public void testReadMultipleSecuritySchemes() {
     String testTD =
-        "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
         "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ] ;\n" +
         "    td:hasBase <http://example.org/> .";
-    
+
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, testTD);
-    
+
     assertTrue(reader.readSecuritySchemes().stream().anyMatch(scheme -> scheme.getSchemeType()
-        .equals(WoTSec.NoSecurityScheme)));
+      .equals(WoTSec.NoSecurityScheme)));
     assertTrue(reader.readSecuritySchemes().stream().anyMatch(scheme -> scheme.getSchemeType()
-        .equals(WoTSec.APIKeySecurityScheme)));
+      .equals(WoTSec.APIKeySecurityScheme)));
   }
-  
+
   @Test
   public void testReadOneSimpleProperty() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     List<PropertyAffordance> properties = reader.readProperties();
     assertEquals(1, properties.size());
-    
+
     PropertyAffordance property = properties.get(0);
-    assertEquals("my_property", property.getName().get());
+    assertEquals("my_property", property.getName());
     assertEquals("My Property", property.getTitle().get());
     assertTrue(property.isObservable());
     assertEquals(2, property.getSemanticTypes().size());
     assertEquals(2, property.getForms().size());
-    
+
     Optional<Form> form = property.getFirstFormForOperationType(TD.readProperty);
     assertTrue(form.isPresent());
     assertEquals("websub", form.get().getSubProtocol().get());
   }
-  
+
   @Test
   public void testReadOneSimpleAction() {
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_SIMPLE_TD);
-    
+
     assertEquals(1, reader.readActions().size());
     ActionAffordance action = reader.readActions().get(0);
-    
-    assertEquals("my_action", action.getName().get());
+
+    assertEquals("my_action", action.getName());
     assertEquals("My Action", action.getTitle().get());
     assertEquals(1, action.getSemanticTypes().size());
     assertEquals(TD.ActionAffordance, action.getSemanticTypes().get(0));
-    
+
     assertEquals(1, action.getForms().size());
     Form form = action.getForms().get(0);
-    
+
     assertForm(form, "PUT", "http://example.org/action", "application/json", TD.invokeAction);
   }
-  
+
   @Test
   public void testReadMultipleSimpleActions() {
     String testTD =
-        "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
         "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
         "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" +
         "@prefix dct: <http://purl.org/dc/terms/> .\n" +
         "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
         "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
+        "<http://example.org/#thing> a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-        "    td:hasBase <http://example.org/> ;\n" + 
-        "    td:hasActionAffordance [\n" + 
-        "        a td:ActionAffordance ;\n" + 
-        "        dct:title \"First Action\" ;\n" + 
-        "        td:hasForm [\n" + 
-        "            htv:methodName \"PUT\" ;\n" + 
-        "            hctl:hasTarget <http://example.org/action1> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:invokeAction;\n" + 
-        "        ] ;\n" + 
-        "    ] ;\n" +
-        "    td:hasActionAffordance [\n" + 
-        "        a td:ActionAffordance ;\n" + 
-        "        dct:title \"Second Action\" ;\n" + 
-        "        td:hasForm [\n" + 
-        "            htv:methodName \"PUT\" ;\n" + 
-        "            hctl:hasTarget <http://example.org/action2> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:invokeAction;\n" + 
+        "    td:hasBase <http://example.org/> ;\n" +
+        "    td:hasActionAffordance [\n" +
+        "        a td:ActionAffordance ;\n" +
+        "        td:name \"first_action\" ;\n" +
+        "        dct:title \"First Action\" ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/action1> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:invokeAction;\n" +
         "        ] ;\n" +
         "    ] ;\n" +
-        "    td:hasActionAffordance [\n" + 
-        "        a td:ActionAffordance ;\n" + 
-        "        dct:title \"Third Action\" ;\n" + 
-        "        td:hasForm [\n" + 
-        "            htv:methodName \"PUT\" ;\n" + 
-        "            hctl:hasTarget <http://example.org/action3> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:invokeAction;\n" + 
-        "        ] ;\n" + 
-        "    ] ." ;
-    
+        "    td:hasActionAffordance [\n" +
+        "        a td:ActionAffordance ;\n" +
+        "        td:name \"second_action\" ;\n" +
+        "        dct:title \"Second Action\" ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/action2> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:invokeAction;\n" +
+        "        ] ;\n" +
+        "    ] ;\n" +
+        "    td:hasActionAffordance [\n" +
+        "        a td:ActionAffordance ;\n" +
+        "        td:name \"third_action\" ;\n" +
+        "        dct:title \"Third Action\" ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/action3> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:invokeAction;\n" +
+        "        ] ;\n" +
+        "    ] .";
+
     TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, testTD);
-    
+
     assertEquals(3, reader.readActions().size());
-    
+
     List<String> actionTitles = reader.readActions().stream().map(action -> action.getTitle().get())
-        .collect(Collectors.toList());
-    
+      .collect(Collectors.toList());
+
     assertTrue(actionTitles.contains("First Action"));
     assertTrue(actionTitles.contains("Second Action"));
     assertTrue(actionTitles.contains("Third Action"));
   }
-  
+
   @Test
   public void testReadOneActionOneObjectInput() {
     String testSimpleObject =
-        "        td:hasInputSchema [\n" + 
-        "            a js:ObjectSchema ;\n" + 
-        "            js:properties [\n" + 
+      "        td:hasInputSchema [\n" +
+        "            a js:ObjectSchema ;\n" +
+        "            js:properties [\n" +
         "                a js:BooleanSchema ;\n" +
         "                js:propertyName \"boolean_value\";\n" +
         "            ] ;\n" +
-        "            js:properties [\n" + 
+        "            js:properties [\n" +
         "                a js:NumberSchema ;\n" +
         "                js:propertyName \"number_value\";\n" +
-        "                js:maximum 100.05 ;\n" + 
+        "                js:maximum 100.05 ;\n" +
         "                js:minimum -100.05 ;\n" +
         "            ] ;\n" +
-        "            js:properties [\n" + 
+        "            js:properties [\n" +
         "                a js:IntegerSchema ;\n" +
         "                js:propertyName \"integer_value\";\n" +
-        "                js:maximum 100 ;\n" + 
+        "                js:maximum 100 ;\n" +
         "                js:minimum -100 ;\n" +
         "            ] ;\n" +
-        "            js:properties [\n" + 
+        "            js:properties [\n" +
         "                a js:StringSchema ;\n" +
         "                js:propertyName \"string_value\";\n" +
         "            ] ;\n" +
-        "            js:properties [\n" + 
+        "            js:properties [\n" +
         "                a js:NullSchema ;\n" +
         "                js:propertyName \"null_value\";\n" +
         "            ] ;\n" +
         "            js:required \"integer_value\", \"number_value\" ;\n" +
         "        ]\n";
-    
-    TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_IO_HEAD + testSimpleObject 
-        + TEST_IO_TAIL);
-    
+
+    TDGraphReader reader = new TDGraphReader(RDFFormat.TURTLE, TEST_IO_HEAD + testSimpleObject
+      + TEST_IO_TAIL);
+
     ActionAffordance action = reader.readActions().get(0);
-    
+
     Optional<DataSchema> input = action.getInputSchema();
     assertTrue(input.isPresent());
     assertEquals(DataSchema.OBJECT, input.get().getDatatype());
-    
+
     ObjectSchema schema = (ObjectSchema) input.get();
     assertEquals(5, schema.getProperties().size());
-    
+
     DataSchema booleanProperty = schema.getProperties().get("boolean_value");
     assertEquals(DataSchema.BOOLEAN, booleanProperty.getDatatype());
-    
+
     DataSchema integerProperty = schema.getProperties().get("integer_value");
     assertEquals(DataSchema.INTEGER, integerProperty.getDatatype());
     assertEquals(-100, ((IntegerSchema) integerProperty).getMinimum().get().intValue());
     assertEquals(100, ((IntegerSchema) integerProperty).getMaximum().get().intValue());
-    
+
     DataSchema numberProperty = schema.getProperties().get("number_value");
     assertEquals(DataSchema.NUMBER, numberProperty.getDatatype());
     assertEquals(-100.05, ((NumberSchema) numberProperty).getMinimum().get().doubleValue(), 0.001);
     assertEquals(100.05, ((NumberSchema) numberProperty).getMaximum().get().doubleValue(), 0.001);
-    
+
     DataSchema stringProperty = schema.getProperties().get("string_value");
     assertEquals(DataSchema.STRING, stringProperty.getDatatype());
-    
+
     DataSchema nullProperty = schema.getProperties().get("null_value");
     assertEquals(DataSchema.NULL, nullProperty.getDatatype());
-    
+
     assertEquals(2, schema.getRequiredProperties().size());
     assertTrue(schema.getRequiredProperties().contains("integer_value"));
     assertTrue(schema.getRequiredProperties().contains("number_value"));
   }
-  
+
   @Test
   public void testReadTDFromFile() throws IOException {
-	  // Read a TD from a File by passing its path as parameter
-	  ThingDescription simple = TDGraphReader.readFromFile(TDFormat.RDF_TURTLE, "samples/simple_td.ttl");
-	  ThingDescription forklift = TDGraphReader.readFromFile(TDFormat.RDF_TURTLE, "samples/forkliftRobot.ttl");
-	  
-	  // Check if a TD was created from the file by checking its title
-	  assertEquals("My Thing", simple.getTitle());
-	  assertEquals("forkliftRobot", forklift.getTitle());
+    // Read a TD from a File by passing its path as parameter
+    ThingDescription simple = TDGraphReader.readFromFile(TDFormat.RDF_TURTLE, "samples/simple_td.ttl");
+    ThingDescription forklift = TDGraphReader.readFromFile(TDFormat.RDF_TURTLE, "samples/forkliftRobot.ttl");
+
+    // Check if a TD was created from the file by checking its title
+    assertEquals("My Thing", simple.getTitle());
+    assertEquals("forkliftRobot", forklift.getTitle());
   }
-  
+
   @Test
   public void testReadSimpleFullTD() {
     ThingDescription td = TDGraphReader.readFromString(TDFormat.RDF_TURTLE, TEST_SIMPLE_TD);
-    
+
     // Check metadata
     assertEquals("My Thing", td.getTitle());
     assertEquals("http://example.org/#thing", td.getThingURI().get());
     assertEquals(1, td.getSemanticTypes().size());
     assertTrue(td.getSemanticTypes().contains("https://www.w3.org/2019/wot/td#Thing"));
     assertTrue(td.getSecuritySchemes().stream().anyMatch(scheme -> scheme.getSchemeType()
-        .equals(WoTSec.NoSecurityScheme)));
+      .equals(WoTSec.NoSecurityScheme)));
     assertEquals(1, td.getActions().size());
-    
+
     // Check action metadata
     ActionAffordance action = td.getActions().get(0);
     assertEquals("My Action", action.getTitle().get());
     assertEquals(1, action.getForms().size());
-    
+
     // Check action form
     Form form = action.getForms().get(0);
     assertForm(form, "PUT", "http://example.org/action", "application/json", TD.invokeAction);
-    
+
     // Check action input data schema
     ObjectSchema input = (ObjectSchema) action.getInputSchema().get();
     assertEquals(DataSchema.OBJECT, input.getDatatype());
     assertEquals(1, input.getProperties().size());
     assertEquals(1, input.getRequiredProperties().size());
-    
+
     assertEquals(DataSchema.NUMBER, input.getProperties().get("number_value").getDatatype());
     assertTrue(input.getRequiredProperties().contains("number_value"));
-    
+
     // Check action output data schema
     ObjectSchema output = (ObjectSchema) action.getOutputSchema().get();
     assertEquals(DataSchema.OBJECT, output.getDatatype());
     assertEquals(1, output.getProperties().size());
     assertEquals(1, output.getRequiredProperties().size());
-    
+
     assertEquals(DataSchema.BOOLEAN, output.getProperties().get("boolean_value").getDatatype());
     assertTrue(output.getRequiredProperties().contains("boolean_value"));
   }
-  
+
   @Test
   public void testMissingMandatoryTitle() {
-  	String testTDWithMissingTitle =
-  	    "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
-  			"@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
-  			"\n" +
-  			"<http://example.org/#thing> a td:Thing ;\n" + 
-  			"    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-  			"    td:hasBase <http://example.org/> .\n" ;
-  	
-  	Exception exception = assertThrows(InvalidTDException.class, () -> {
-  		TDGraphReader.readFromString(TDFormat.RDF_TURTLE, testTDWithMissingTitle);
+    String testTDWithMissingTitle =
+      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+        "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
+        "\n" +
+        "<http://example.org/#thing> a td:Thing ;\n" +
+        "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
+        "    td:hasBase <http://example.org/> .\n";
+
+    Exception exception = assertThrows(InvalidTDException.class, () -> {
+      TDGraphReader.readFromString(TDFormat.RDF_TURTLE, testTDWithMissingTitle);
     });
-  	
-  	String expectedMessage = "Missing mandatory title.";
+
+    String expectedMessage = "Missing mandatory title.";
     String actualMessage = exception.getMessage();
- 
-    assertTrue(actualMessage.contains(expectedMessage));	
+
+    assertTrue(actualMessage.contains(expectedMessage));
   }
-  
-  private void assertForm(Form form, String methodName, String target, 
-      String contentType, String operationType) {
+
+  @Test
+  public void testMissingMandatoryPropertyAffordanceName() {
+    String testTDWithMissingAffordanceName =
+      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+        "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
+        "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" +
+        "@prefix dct: <http://purl.org/dc/terms/> .\n" +
+        "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
+        "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
+        "\n" +
+        "<http://example.org/#thing> a td:Thing ;\n" +
+        "    dct:title \"My Thing\" ;\n" +
+        "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
+        "    td:hasPropertyAffordance [\n" +
+        "        a td:PropertyAffordance, js:NumberSchema ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/property> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:writeProperty;\n" +
+        "        ] ;\n" +
+        "    ] .";
+
+    Exception exception = assertThrows(InvalidTDException.class, () -> {
+      TDGraphReader.readFromString(TDFormat.RDF_TURTLE, testTDWithMissingAffordanceName);
+    });
+
+    StringWriter writer = new StringWriter();
+    exception.printStackTrace(new PrintWriter(writer));
+    String expectedMessage = "Invalid property definition.";
+    String expectedRootMessage = "Missing mandatory affordance name.";
+    String actualMessage = writer.toString();
+
+    assertTrue(actualMessage.contains(expectedMessage));
+    assertTrue(actualMessage.contains(expectedRootMessage));
+  }
+
+  @Test
+  public void testMissingMandatoryActionAffordanceName() {
+    String testTDWithMissingAffordanceName =
+      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+        "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
+        "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" +
+        "@prefix dct: <http://purl.org/dc/terms/> .\n" +
+        "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
+        "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
+        "\n" +
+        "<http://example.org/#thing> a td:Thing ;\n" +
+        "    dct:title \"My Thing\" ;\n" +
+        "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
+        "    td:hasActionAffordance [\n" +
+        "        a td:ActionAffordance ;\n" +
+        "        td:hasForm [\n" +
+        "            htv:methodName \"PUT\" ;\n" +
+        "            hctl:hasTarget <http://example.org/action> ;\n" +
+        "            hctl:forContentType \"application/json\";\n" +
+        "            hctl:hasOperationType td:invokeAction;\n" +
+        "        ] ;\n" +
+        "    ] .";
+
+    Exception exception = assertThrows(InvalidTDException.class, () -> {
+      TDGraphReader.readFromString(TDFormat.RDF_TURTLE, testTDWithMissingAffordanceName);
+    });
+
+    StringWriter writer = new StringWriter();
+    exception.printStackTrace(new PrintWriter(writer));
+    String expectedMessage = "Invalid action definition.";
+    String expectedRootMessage = "Missing mandatory affordance name.";
+    String actualMessage = writer.toString();
+
+    assertTrue(actualMessage.contains(expectedMessage));
+    assertTrue(actualMessage.contains(expectedRootMessage));
+  }
+
+  private void assertForm(Form form, String methodName, String target,
+                          String contentType, String operationType) {
     assertEquals(methodName, form.getMethodName().get());
     assertEquals(target, form.getTarget());
     assertEquals(contentType, form.getContentType());
     assertTrue(form.hasOperationType(operationType));
   }
-  
+
 }

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriterTest.java
@@ -1,12 +1,16 @@
 package ch.unisg.ics.interactions.wot.td.io;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
+import ch.unisg.ics.interactions.wot.td.ThingDescription;
+import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
+import ch.unisg.ics.interactions.wot.td.affordances.Form;
+import ch.unisg.ics.interactions.wot.td.affordances.PropertyAffordance;
+import ch.unisg.ics.interactions.wot.td.schemas.BooleanSchema;
+import ch.unisg.ics.interactions.wot.td.schemas.IntegerSchema;
+import ch.unisg.ics.interactions.wot.td.schemas.NumberSchema;
+import ch.unisg.ics.interactions.wot.td.schemas.ObjectSchema;
+import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme;
+import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme.TokenLocation;
+import ch.unisg.ics.interactions.wot.td.security.NoSecurityScheme;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -21,399 +25,396 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.junit.Test;
 
-import ch.unisg.ics.interactions.wot.td.ThingDescription;
-import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
-import ch.unisg.ics.interactions.wot.td.affordances.Form;
-import ch.unisg.ics.interactions.wot.td.affordances.PropertyAffordance;
-import ch.unisg.ics.interactions.wot.td.schemas.BooleanSchema;
-import ch.unisg.ics.interactions.wot.td.schemas.IntegerSchema;
-import ch.unisg.ics.interactions.wot.td.schemas.NumberSchema;
-import ch.unisg.ics.interactions.wot.td.schemas.ObjectSchema;
-import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme;
-import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme.TokenLocation;
-import ch.unisg.ics.interactions.wot.td.security.NoSecurityScheme;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
 
 public class TDGraphWriterTest {
   private static final String THING_TITLE = "My Thing";
   private static final String THING_IRI = "http://example.org/#thing";
   private static final String IO_BASE_IRI = "http://example.org/";
-  
+
   private static final String PREFIXES =
-      "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
+    "@prefix td: <https://www.w3.org/2019/wot/td#> .\n" +
       "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
       "@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .\n" +
       "@prefix dct: <http://purl.org/dc/terms/> .\n" +
       "@prefix wotsec: <https://www.w3.org/2019/wot/security#> .\n" +
-      "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" + 
-      "@prefix saref: <https://saref.etsi.org/core/> .\n" + 
+      "@prefix js: <https://www.w3.org/2019/wot/json-schema#> .\n" +
+      "@prefix saref: <https://saref.etsi.org/core/> .\n" +
       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n";
-  
+
   @Test
   public void testNoThingURI() throws RDFParseException, RDFHandlerException, IOException {
-    String testTD = 
-        PREFIXES +
+    String testTD =
+      PREFIXES +
         "\n" +
-        "[] a td:Thing ;\n" + 
+        "[] a td:Thing ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n";
-    
+
     ThingDescription td = new ThingDescription.Builder(THING_TITLE)
-        .addSecurityScheme(new NoSecurityScheme())
-        .build();
-    
+      .addSecurityScheme(new NoSecurityScheme())
+      .build();
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteTitle() throws RDFParseException, RDFHandlerException, IOException {
     String testTD = PREFIXES +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
-        "    dct:title \"My Thing\" ;\n" +
-        "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n" ;
-    
+      "<http://example.org/#thing> a td:Thing ;\n" +
+      "    dct:title \"My Thing\" ;\n" +
+      "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n";
+
     ThingDescription td = new ThingDescription.Builder(THING_TITLE)
-        .addThingURI(THING_IRI)
-        .addSecurityScheme(new NoSecurityScheme())
-        .build();
-    
+      .addThingURI(THING_IRI)
+      .addSecurityScheme(new NoSecurityScheme())
+      .build();
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteAPIKeySecurityScheme() throws RDFParseException, RDFHandlerException, IOException {
     String testTD = PREFIXES +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
-        "    dct:title \"My Thing\" ;\n" +
-        "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ;\n" +
-        "        wotsec:in \"HEADER\" ;\n" +
-        "        wotsec:name \"X-API-Key\" ;\n" +
-        "    ] .\n";
-    
+      "<http://example.org/#thing> a td:Thing ;\n" +
+      "    dct:title \"My Thing\" ;\n" +
+      "    td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme ;\n" +
+      "        wotsec:in \"HEADER\" ;\n" +
+      "        wotsec:name \"X-API-Key\" ;\n" +
+      "    ] .\n";
+
     ThingDescription td = new ThingDescription.Builder(THING_TITLE)
-        .addThingURI(THING_IRI)
-        .addSecurityScheme(new APIKeySecurityScheme(TokenLocation.HEADER, "X-API-Key"))
-        .build();
-    
+      .addThingURI(THING_IRI)
+      .addSecurityScheme(new APIKeySecurityScheme(TokenLocation.HEADER, "X-API-Key"))
+      .build();
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteAdditionalTypes() throws RDFParseException, RDFHandlerException, IOException {
-    String testTD = 
-        PREFIXES +
+    String testTD =
+      PREFIXES +
         "@prefix eve: <http://w3id.org/eve#> .\n" +
         "@prefix iot: <http://iotschema.org/> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing, eve:Artifact, iot:Light ;\n" + 
+        "<http://example.org/#thing> a td:Thing, eve:Artifact, iot:Light ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n";
-    
+
     ThingDescription td = new ThingDescription.Builder(THING_TITLE)
-        .addThingURI(THING_IRI)
-        .addSemanticType("http://w3id.org/eve#Artifact")
-        .addSemanticType("http://iotschema.org/Light")
-        .addSecurityScheme(new NoSecurityScheme())
-        .build();
-    
+      .addThingURI(THING_IRI)
+      .addSemanticType("http://w3id.org/eve#Artifact")
+      .addSemanticType("http://iotschema.org/Light")
+      .addSecurityScheme(new NoSecurityScheme())
+      .build();
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
-  public void testWriteTypesDeduplication() throws RDFParseException, RDFHandlerException, 
-      IOException {
-    
-    String testTD = 
-        PREFIXES +
+  public void testWriteTypesDeduplication() throws RDFParseException, RDFHandlerException,
+    IOException {
+
+    String testTD =
+      PREFIXES +
         "@prefix eve: <http://w3id.org/eve#> .\n" +
         "\n" +
-        "<http://example.org/#thing> a td:Thing, eve:Artifact ;\n" + 
+        "<http://example.org/#thing> a td:Thing, eve:Artifact ;\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] .\n";
-    
+
     ThingDescription td = new ThingDescription.Builder(THING_TITLE)
-        .addThingURI(THING_IRI)
-        .addSemanticType("http://w3id.org/eve#Artifact")
-        .addSemanticType("http://w3id.org/eve#Artifact")
-        .addSecurityScheme(new NoSecurityScheme())
-        .build();
-    
+      .addThingURI(THING_IRI)
+      .addSemanticType("http://w3id.org/eve#Artifact")
+      .addSemanticType("http://w3id.org/eve#Artifact")
+      .addSecurityScheme(new NoSecurityScheme())
+      .build();
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteBaseURI() throws RDFParseException, RDFHandlerException, IOException {
-    String testTD = 
-        PREFIXES +
+    String testTD =
+      PREFIXES +
         "\n" +
         "<http://example.org/#thing> a td:Thing ;\n" +
         "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" +
         "    dct:title \"My Thing\" ;\n" +
         "    td:hasBase <http://example.org/> .\n";
-    
+
     ThingDescription td = new ThingDescription.Builder(THING_TITLE)
-        .addThingURI(THING_IRI)
-        .addBaseURI("http://example.org/")
-        .build();
-    
+      .addThingURI(THING_IRI)
+      .addBaseURI("http://example.org/")
+      .build();
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteOnePropertyDefaultValues() throws RDFParseException, RDFHandlerException,
-      IOException {
+    IOException {
     String testTD = PREFIXES +
-        "@prefix iot: <http://iotschema.org/> .\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
-        "    dct:title \"My Thing\" ;\n" +
-        "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-        "    td:hasPropertyAffordance [\n" + 
-        "        a td:PropertyAffordance, js:IntegerSchema, iot:MyProperty ;\n" +
-        "        td:name \"my_property\" ;\n" +
-        "        td:isObservable true ;\n" +
-        "        td:hasForm [\n" + 
-        "            hctl:hasTarget <http://example.org/count> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:readProperty, td:writeProperty;\n" + 
-        "        ] ;\n" + 
-        "    ] ." ;
-    
-    
-    PropertyAffordance property = new PropertyAffordance.Builder(new IntegerSchema.Builder().build(), 
-            new Form.Builder("http://example.org/count").build())
-        .addSemanticType("http://iotschema.org/MyProperty")
-        .addName("my_property")
-        .addObserve()
-        .build();
-    
+      "@prefix iot: <http://iotschema.org/> .\n" +
+      "<http://example.org/#thing> a td:Thing ;\n" +
+      "    dct:title \"My Thing\" ;\n" +
+      "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
+      "    td:hasPropertyAffordance [\n" +
+      "        a td:PropertyAffordance, js:IntegerSchema, iot:MyProperty ;\n" +
+      "        td:name \"my_property\" ;\n" +
+      "        td:isObservable true ;\n" +
+      "        td:hasForm [\n" +
+      "            hctl:hasTarget <http://example.org/count> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:readProperty, td:writeProperty;\n" +
+      "        ] ;\n" +
+      "    ] .";
+
+
+    PropertyAffordance property = new PropertyAffordance.Builder("my_property",
+      new IntegerSchema.Builder().build(),
+      new Form.Builder("http://example.org/count").build())
+      .addSemanticType("http://iotschema.org/MyProperty")
+      .addObserve()
+      .build();
+
     ThingDescription td = new ThingDescription.Builder(THING_TITLE)
-        .addThingURI(THING_IRI)
-        .addSecurityScheme(new NoSecurityScheme())
-        .addProperty(property)
-        .build();
-    
+      .addThingURI(THING_IRI)
+      .addSecurityScheme(new NoSecurityScheme())
+      .addProperty(property)
+      .build();
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWritePropertySubprotocol() throws RDFParseException, RDFHandlerException,
-      IOException {
+    IOException {
     String testTD = PREFIXES +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
-        "    dct:title \"My Thing\" ;\n" +
-        "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-        "    td:hasBase <http://example.org/> ;\n" + 
-        "    td:hasPropertyAffordance [\n" + 
-        "        a td:PropertyAffordance, js:IntegerSchema ;\n" +
-        "        td:isObservable true ;\n" +
-        "        td:hasForm [\n" + 
-        "            hctl:hasTarget <http://example.org/count> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:readProperty, td:writeProperty;\n" +
-        "            hctl:forSubProtocol \"websub\";\n" +
-        "        ] ;\n" + 
-        "    ] ." ;
-    
-    
-    PropertyAffordance property = new PropertyAffordance.Builder(new IntegerSchema.Builder().build(), 
-            new Form.Builder("http://example.org/count")
-                .addSubProtocol("websub")
-                .build())
-        .addObserve()
-        .build();
-    
-    ThingDescription td = constructThingDescription(new ArrayList<PropertyAffordance>(Arrays.asList(property)), 
-        new ArrayList<ActionAffordance>(Arrays.asList()));
-    
+      "<http://example.org/#thing> a td:Thing ;\n" +
+      "    dct:title \"My Thing\" ;\n" +
+      "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
+      "    td:hasBase <http://example.org/> ;\n" +
+      "    td:hasPropertyAffordance [\n" +
+      "        a td:PropertyAffordance, js:IntegerSchema ;\n" +
+      "        td:name \"my_property\" ;\n" +
+      "        td:isObservable true ;\n" +
+      "        td:hasForm [\n" +
+      "            hctl:hasTarget <http://example.org/count> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:readProperty, td:writeProperty;\n" +
+      "            hctl:forSubProtocol \"websub\";\n" +
+      "        ] ;\n" +
+      "    ] .";
+
+
+    PropertyAffordance property = new PropertyAffordance.Builder("my_property",
+      new IntegerSchema.Builder().build(),
+      new Form.Builder("http://example.org/count")
+        .addSubProtocol("websub")
+        .build())
+      .addObserve()
+      .build();
+
+    ThingDescription td = constructThingDescription(new ArrayList<PropertyAffordance>(Arrays.asList(property)),
+      new ArrayList<ActionAffordance>(Arrays.asList()));
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteOneAction() throws RDFParseException, RDFHandlerException, IOException {
     String testTD = PREFIXES +
-        "@prefix iot: <http://iotschema.org/> .\n" +
-        "\n" +
-        "<http://example.org/#thing> a td:Thing ;\n" + 
-        "    dct:title \"My Thing\" ;\n" +
-        "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
-        "    td:hasBase <http://example.org/> ;\n" + 
-        "    td:hasActionAffordance [\n" + 
-        "        a td:ActionAffordance, iot:MyAction ;\n" +
-        "        td:name \"my_action\" ;\n" + 
-        "        dct:title \"My Action\" ;\n" + 
-        "        td:hasForm [\n" + 
-        "            htv:methodName \"PUT\" ;\n" + 
-        "            hctl:hasTarget <http://example.org/action> ;\n" + 
-        "            hctl:forContentType \"application/json\";\n" + 
-        "            hctl:hasOperationType td:invokeAction;\n" + 
-        "        ] ;\n" + 
-        "        td:hasInputSchema [\n" + 
-        "            a js:ObjectSchema ;\n" + 
-        "            js:properties [\n" + 
-        "                a js:NumberSchema ;\n" +
-        "                js:propertyName \"number_value\";\n" +
-        "            ] ;\n" +
-        "            js:required \"number_value\" ;\n" +
-        "        ] ;\n" + 
-        "        td:hasOutputSchema [\n" + 
-        "            a js:ObjectSchema ;\n" + 
-        "            js:properties [\n" + 
-        "                a js:BooleanSchema ;\n" +
-        "                js:propertyName \"boolean_value\";\n" +
-        "            ] ;\n" +
-        "            js:required \"boolean_value\" ;\n" +
-        "        ]\n" + 
-        "    ] ." ;
-    
-    ActionAffordance simpleAction = new ActionAffordance.Builder(
-            new Form.Builder( "http://example.org/action")
-              .setMethodName("PUT")
-              .build())
-        .addName("my_action")
-        .addTitle("My Action")
-        .addSemanticType("http://iotschema.org/MyAction")
-        .addInputSchema(new ObjectSchema.Builder()
-            .addProperty("number_value", new NumberSchema.Builder().build())
-            .addRequiredProperties("number_value")
-            .build())
-        .addOutputSchema(new ObjectSchema.Builder()
-            .addProperty("boolean_value", new BooleanSchema.Builder().build())
-            .addRequiredProperties("boolean_value")
-            .build())
-        .build();
-    
-    ThingDescription td = constructThingDescription(new ArrayList<PropertyAffordance>(), 
-        new ArrayList<ActionAffordance>(Arrays.asList(simpleAction)));
-    
+      "@prefix iot: <http://iotschema.org/> .\n" +
+      "\n" +
+      "<http://example.org/#thing> a td:Thing ;\n" +
+      "    dct:title \"My Thing\" ;\n" +
+      "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ] ;\n" +
+      "    td:hasBase <http://example.org/> ;\n" +
+      "    td:hasActionAffordance [\n" +
+      "        a td:ActionAffordance, iot:MyAction ;\n" +
+      "        td:name \"my_action\" ;\n" +
+      "        dct:title \"My Action\" ;\n" +
+      "        td:hasForm [\n" +
+      "            htv:methodName \"PUT\" ;\n" +
+      "            hctl:hasTarget <http://example.org/action> ;\n" +
+      "            hctl:forContentType \"application/json\";\n" +
+      "            hctl:hasOperationType td:invokeAction;\n" +
+      "        ] ;\n" +
+      "        td:hasInputSchema [\n" +
+      "            a js:ObjectSchema ;\n" +
+      "            js:properties [\n" +
+      "                a js:NumberSchema ;\n" +
+      "                js:propertyName \"number_value\";\n" +
+      "            ] ;\n" +
+      "            js:required \"number_value\" ;\n" +
+      "        ] ;\n" +
+      "        td:hasOutputSchema [\n" +
+      "            a js:ObjectSchema ;\n" +
+      "            js:properties [\n" +
+      "                a js:BooleanSchema ;\n" +
+      "                js:propertyName \"boolean_value\";\n" +
+      "            ] ;\n" +
+      "            js:required \"boolean_value\" ;\n" +
+      "        ]\n" +
+      "    ] .";
+
+    ActionAffordance simpleAction = new ActionAffordance.Builder("my_action",
+      new Form.Builder("http://example.org/action")
+        .setMethodName("PUT")
+        .build())
+      .addTitle("My Action")
+      .addSemanticType("http://iotschema.org/MyAction")
+      .addInputSchema(new ObjectSchema.Builder()
+        .addProperty("number_value", new NumberSchema.Builder().build())
+        .addRequiredProperties("number_value")
+        .build())
+      .addOutputSchema(new ObjectSchema.Builder()
+        .addProperty("boolean_value", new BooleanSchema.Builder().build())
+        .addRequiredProperties("boolean_value")
+        .build())
+      .build();
+
+    ThingDescription td = constructThingDescription(new ArrayList<PropertyAffordance>(),
+      new ArrayList<ActionAffordance>(Arrays.asList(simpleAction)));
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteAdditionalMetadata() throws RDFParseException, RDFHandlerException, IOException {
-  	String testTD = PREFIXES +
-  	    "@prefix eve: <http://w3id.org/eve#> .\n" +
-  	    "<http://example.org/lamp123> a td:Thing, saref:LightSwitch;\n" + 
-  	    "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" + 
-  	    "    dct:title \"My Lamp Thing\" ;\n" +
-  	    "    eve:hasManual [ a eve:Manual;\n" +
-  	    "        dct:title \"My Lamp Manual\";\n" +
-  	    "        eve:hasUsageProtocol [ a eve:UsageProtocol;\n" +
-  	    "            dct:title \"Party Light\";\n" +
-  	    "            eve:hasLanguage <http://jason.sourceforge.net/wp/description/>\n" +
-  	    "        ]\n" +
-  	    "    ].\n" ;
-  	    
-  	ValueFactory rdf = SimpleValueFactory.getInstance();
-  	Model metadata = new LinkedHashModel();
-  	
-  	final String NS = "http://w3id.org/eve#";
-  	metadata.setNamespace("eve", NS);
-  	  	
+    String testTD = PREFIXES +
+      "@prefix eve: <http://w3id.org/eve#> .\n" +
+      "<http://example.org/lamp123> a td:Thing, saref:LightSwitch;\n" +
+      "    td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" +
+      "    dct:title \"My Lamp Thing\" ;\n" +
+      "    eve:hasManual [ a eve:Manual;\n" +
+      "        dct:title \"My Lamp Manual\";\n" +
+      "        eve:hasUsageProtocol [ a eve:UsageProtocol;\n" +
+      "            dct:title \"Party Light\";\n" +
+      "            eve:hasLanguage <http://jason.sourceforge.net/wp/description/>\n" +
+      "        ]\n" +
+      "    ].\n";
+
+    ValueFactory rdf = SimpleValueFactory.getInstance();
+    Model metadata = new LinkedHashModel();
+
+    final String NS = "http://w3id.org/eve#";
+    metadata.setNamespace("eve", NS);
+
     BNode manualId = rdf.createBNode();
-  	BNode protocolId = rdf.createBNode();
-  	metadata.add(rdf.createIRI("http://example.org/lamp123"), rdf.createIRI(NS,"hasManual"), manualId);
-  	metadata.add(manualId, RDF.TYPE, rdf.createIRI(NS, "Manual"));
-  	metadata.add(manualId, DCTERMS.TITLE, rdf.createLiteral("My Lamp Manual"));
-  	  	
-  	ThingDescription td = new ThingDescription.Builder("My Lamp Thing")
-  	    .addThingURI("http://example.org/lamp123")
-  	    .addSemanticType("https://saref.etsi.org/core/LightSwitch")
-  	    .addTriple(protocolId, RDF.TYPE, rdf.createIRI(NS, "UsageProtocol"))
-  	    .addTriple(protocolId, DCTERMS.TITLE, rdf.createLiteral("Party Light"))
-  	    .addGraph(metadata)
-  	    .addGraph(new ModelBuilder()
-  	        .add(manualId, rdf.createIRI(NS, "hasUsageProtocol"), protocolId)
-  	        .build())  	    
-  	    .addTriple(protocolId, rdf.createIRI(NS,"hasLanguage"), rdf.createIRI("http://jason.sourceforge.net/wp/description/"))
-  	    .build();
-  	
-    assertIsomorphicGraphs(testTD, td);    
+    BNode protocolId = rdf.createBNode();
+    metadata.add(rdf.createIRI("http://example.org/lamp123"), rdf.createIRI(NS, "hasManual"), manualId);
+    metadata.add(manualId, RDF.TYPE, rdf.createIRI(NS, "Manual"));
+    metadata.add(manualId, DCTERMS.TITLE, rdf.createLiteral("My Lamp Manual"));
+
+    ThingDescription td = new ThingDescription.Builder("My Lamp Thing")
+      .addThingURI("http://example.org/lamp123")
+      .addSemanticType("https://saref.etsi.org/core/LightSwitch")
+      .addTriple(protocolId, RDF.TYPE, rdf.createIRI(NS, "UsageProtocol"))
+      .addTriple(protocolId, DCTERMS.TITLE, rdf.createLiteral("Party Light"))
+      .addGraph(metadata)
+      .addGraph(new ModelBuilder()
+        .add(manualId, rdf.createIRI(NS, "hasUsageProtocol"), protocolId)
+        .build())
+      .addTriple(protocolId, rdf.createIRI(NS, "hasLanguage"), rdf.createIRI("http://jason.sourceforge.net/wp/description/"))
+      .build();
+
+    assertIsomorphicGraphs(testTD, td);
   }
-  
+
   @Test
   public void testWriteReadmeExample() throws RDFParseException, RDFHandlerException, IOException {
     String testTD = PREFIXES +
-        "<http://example.org/lamp123> a td:Thing, saref:LightSwitch;\n" + 
-        "  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" + 
-        "  dct:title \"My Lamp Thing\" ;\n" + 
-        "  td:hasActionAffordance [ a td:ActionAffordance, saref:ToggleCommand;\n" + 
-        "      dct:title \"Toggle\";\n" +
-        "      td:hasForm [\n" + 
-        "          htv:methodName \"PUT\";\n" + 
-        "          hctl:forContentType \"application/json\";\n" + 
-        "          hctl:hasTarget <http://mylamp.example.org/toggle>;\n" + 
-        "          hctl:hasOperationType td:invokeAction\n" + 
-        "        ];\n" + 
-        "      td:hasInputSchema [ a saref:OnOffState, js:ObjectSchema;\n" +
-        "          js:properties [ a js:BooleanSchema;\n" + 
-        "              js:propertyName \"status\"\n" + 
-        "            ];\n" + 
-        "          js:required \"status\"\n" + 
-        "        ];\n" + 
-        "    ].";
-    
+      "<http://example.org/lamp123> a td:Thing, saref:LightSwitch;\n" +
+      "  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme ];\n" +
+      "  dct:title \"My Lamp Thing\" ;\n" +
+      "  td:hasActionAffordance [ a td:ActionAffordance, saref:ToggleCommand;\n" +
+      "      td:name \"toggle\";\n" +
+      "      dct:title \"Toggle\";\n" +
+      "      td:hasForm [\n" +
+      "          htv:methodName \"PUT\";\n" +
+      "          hctl:forContentType \"application/json\";\n" +
+      "          hctl:hasTarget <http://mylamp.example.org/toggle>;\n" +
+      "          hctl:hasOperationType td:invokeAction\n" +
+      "        ];\n" +
+      "      td:hasInputSchema [ a saref:OnOffState, js:ObjectSchema;\n" +
+      "          js:properties [ a js:BooleanSchema;\n" +
+      "              js:propertyName \"status\"\n" +
+      "            ];\n" +
+      "          js:required \"status\"\n" +
+      "        ];\n" +
+      "    ].";
+
     Form toggleForm = new Form.Builder("http://mylamp.example.org/toggle")
-        .setMethodName("PUT")
-        .build();
-    
-    ActionAffordance toggle = new ActionAffordance.Builder(toggleForm)
-        .addTitle("Toggle")
-        .addSemanticType("https://saref.etsi.org/core/ToggleCommand")
-        .addInputSchema(new ObjectSchema.Builder()
-            .addSemanticType("https://saref.etsi.org/core/OnOffState")
-            .addProperty("status", new BooleanSchema.Builder()
-                .build())
-            .addRequiredProperties("status")
-            .build())
-        .build();
-    
+      .setMethodName("PUT")
+      .build();
+
+    ActionAffordance toggle = new ActionAffordance.Builder("toggle", toggleForm)
+      .addTitle("Toggle")
+      .addSemanticType("https://saref.etsi.org/core/ToggleCommand")
+      .addInputSchema(new ObjectSchema.Builder()
+        .addSemanticType("https://saref.etsi.org/core/OnOffState")
+        .addProperty("status", new BooleanSchema.Builder()
+          .build())
+        .addRequiredProperties("status")
+        .build())
+      .build();
+
     ThingDescription td = new ThingDescription.Builder("My Lamp Thing")
-        .addThingURI("http://example.org/lamp123")
-        .addSemanticType("https://saref.etsi.org/core/LightSwitch")
-        .addAction(toggle)
-        .build();
-    
+      .addThingURI("http://example.org/lamp123")
+      .addSemanticType("https://saref.etsi.org/core/LightSwitch")
+      .addAction(toggle)
+      .build();
+
     assertIsomorphicGraphs(testTD, td);
   }
-  
-  private void assertIsomorphicGraphs(String expectedTD, ThingDescription td) throws RDFParseException, 
-      RDFHandlerException, IOException {
-    Model expectedModel = ReadWriteUtils.readModelFromString(RDFFormat.TURTLE, expectedTD, 
-        IO_BASE_IRI);
-    
+
+  private void assertIsomorphicGraphs(String expectedTD, ThingDescription td) throws RDFParseException,
+    RDFHandlerException, IOException {
+    Model expectedModel = ReadWriteUtils.readModelFromString(RDFFormat.TURTLE, expectedTD,
+      IO_BASE_IRI);
+
     String description = new TDGraphWriter(td)
-        .setNamespace("td", "https://www.w3.org/2019/wot/td#")
-        .setNamespace("htv", "http://www.w3.org/2011/http#")
-        .setNamespace("hctl", "https://www.w3.org/2019/wot/hypermedia#")
-        .setNamespace("wotsec", "https://www.w3.org/2019/wot/security#")
-        .setNamespace("dct", "http://purl.org/dc/terms/")
-        .setNamespace("js", "https://www.w3.org/2019/wot/json-schema#")
-        .setNamespace("saref", "https://saref.etsi.org/core/")
-        .write();
-    
+      .setNamespace("td", "https://www.w3.org/2019/wot/td#")
+      .setNamespace("htv", "http://www.w3.org/2011/http#")
+      .setNamespace("hctl", "https://www.w3.org/2019/wot/hypermedia#")
+      .setNamespace("wotsec", "https://www.w3.org/2019/wot/security#")
+      .setNamespace("dct", "http://purl.org/dc/terms/")
+      .setNamespace("js", "https://www.w3.org/2019/wot/json-schema#")
+      .setNamespace("saref", "https://saref.etsi.org/core/")
+      .write();
+
     System.out.println(description);
-    
-    Model tdModel = ReadWriteUtils.readModelFromString(RDFFormat.TURTLE, description, 
-        IO_BASE_IRI);
-    
+
+    Model tdModel = ReadWriteUtils.readModelFromString(RDFFormat.TURTLE, description,
+      IO_BASE_IRI);
+
     assertTrue(Models.isomorphic(expectedModel, tdModel));
-   
+
   }
-  
-  private ThingDescription constructThingDescription(List<PropertyAffordance> properties, 
-      List<ActionAffordance> actions) {
+
+  private ThingDescription constructThingDescription(List<PropertyAffordance> properties,
+                                                     List<ActionAffordance> actions) {
     ThingDescription.Builder builder = new ThingDescription.Builder(THING_TITLE)
-        .addThingURI(THING_IRI)
-        .addBaseURI("http://example.org/")
-        .addSecurityScheme(new NoSecurityScheme());
-    
+      .addThingURI(THING_IRI)
+      .addBaseURI("http://example.org/")
+      .addSecurityScheme(new NoSecurityScheme());
+
     for (PropertyAffordance property : properties) {
       builder.addProperty(property);
     }
-    
+
     for (ActionAffordance action : actions) {
       builder.addAction(action);
     }
-    
+
     return builder.build();
   }
 }


### PR DESCRIPTION
- Make `name` `final` and non-optional on `InteractionAffordance` constructor
- Pass `name` to `Builder` of `InteractionAffordance` (removed `addName()`)
- Throw an `InvalidTDException` on calling `InteractionAffordance` constructor with `null` value for `name` 
- Throw an `InvalidTDException` on calling `ThingDescription` constructor with `null` value for `title`
- Updated `TDGraphReader` to throw an `InvalidTDException` when reading TD with missing affordance names

For the above, see tests on `InteractionAffordanceTest`, `ThingDescriptionTest`, `TDGraphReaderTest`

The rest are fixes to match the updated constructor.

closes #45 