### PR TITLE
Set rdf4j-runtime as transitive dependency (Fix #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Maven:
 
 Gradle:
 ```groovy
-implementation 'com.github.Interactions-HSG:wot-td-java:v0.1.0'
+implementation 'com.github.Interactions-HSG:wot-td-java:v0.1.1'
 ```
 
 Maven:
@@ -63,7 +63,7 @@ Maven:
 <dependency>
   <groupId>com.github.Interactions-HSG</groupId>
   <artifactId>wot-td-java</artifactId>
-  <version>v0.1.0</version>
+  <version>v0.1.1</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
   withSourcesJar()
 }
 
-version '0.1.0'
+version '0.1.1'
 
 repositories {
   jcenter()
@@ -48,7 +48,7 @@ publishing {
       from components.java
       groupId 'ch.unisg.ics.interactions'
       artifactId 'wot-td-java'
-      version '0.1.0'
+      version '0.1.1'
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
   withSourcesJar()
 }
 
-version '0.0.1'
+version '0.1.0'
 
 repositories {
   jcenter()
@@ -22,8 +22,11 @@ dependencies {
   implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.1.2'
   implementation 'org.eclipse.californium:californium-core:2.6.3'
   implementation 'com.google.code.gson:gson:2.8.9'
-  implementation 'org.eclipse.rdf4j:rdf4j-runtime:3.7.4'
   implementation 'org.slf4j:slf4j-api:2.0.0-alpha5'
+
+  implementation('org.eclipse.rdf4j:rdf4j-runtime:3.7.4@pom') {
+    transitive = true;
+  }
 
   // Use JUnit test framework
   testImplementation 'junit:junit:4.13.2'
@@ -45,7 +48,7 @@ publishing {
       from components.java
       groupId 'ch.unisg.ics.interactions'
       artifactId 'wot-td-java'
-      version '0.0.1'
+      version '0.1.0'
     }
   }
 


### PR DESCRIPTION
Updates build configuration to set `rdf4j-runtime` as a transitive dependency of type pom. This fixes #64 .