### PR TITLE
Feature/retrieve form by protocol

### DIFF
--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/Form.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/Form.java
@@ -9,16 +9,16 @@ public class Form {
   private final String target;
   private final String contentType;
   private final Set<String> operationTypes;
-  private final Optional<String> subprotocol;
+  private final Optional<String> subProtocol;
   private Optional<String> methodName;
 
   private Form(String href, Optional<String> methodName, String mediaType, Set<String> operationTypes,
-               Optional<String> subprotocol) {
+               Optional<String> subProtocol) {
     this.methodName = methodName;
     this.target = href;
     this.contentType = mediaType;
     this.operationTypes = operationTypes;
-    this.subprotocol = subprotocol;
+    this.subProtocol = subProtocol;
   }
 
   public Optional<String> getMethodName() {
@@ -58,28 +58,42 @@ public class Form {
     return operationTypes;
   }
 
-  public Optional<String> getSubprotocol() {
-    return subprotocol;
+  public Optional<String> getSubProtocol() {
+    return subProtocol;
   }
 
   // Package-level access, used for setting affordance-specific default values after instantiation
   // Reserved for event affordances of op subscribeevent
   /*
-  void addSubprotocol(String subprotocol) {
-    this.subprotocol = Optional.of(subprotocol);
+  void addSubProtocol(String subProtocol) {
+    this.subProtocol = Optional.of(subProtocol);
   }
   */
 
-  public Optional<String> getSubprotocol(String operationType) {
+  public boolean hasSubProtocol(String operationType, String subProtocol) {
+    Optional<String> targetSubProtocol = getSubProtocol(operationType);
+    return targetSubProtocol.isPresent() && subProtocol.equals(targetSubProtocol.get());
+  }
+
+  public Optional<String> getSubProtocol(String operationType) {
     if (!operationTypes.contains(operationType)) {
       throw new IllegalArgumentException("Unknown operation type: " + operationType);
     }
 
-    if (subprotocol.isPresent()) {
-      return subprotocol;
+    if (subProtocol.isPresent()) {
+      return subProtocol;
     }
 
-    return ProtocolBinding.getDefaultSubprotocol(target, operationType);
+    return ProtocolBinding.getDefaultSubProtocol(target, operationType);
+  }
+
+  public boolean hasProtocol(String protocol) {
+    Optional<String> targetProtocol = ProtocolBinding.getProtocol(target);
+    return targetProtocol.isPresent() && protocol.equals(targetProtocol.get());
+  }
+
+  public Optional<String> getProtocol() {
+    return ProtocolBinding.getProtocol(target);
   }
 
   // Package-level access, used for setting affordance-specific default values after instantiation
@@ -92,14 +106,14 @@ public class Form {
     private final Set<String> operationTypes;
     private Optional<String> methodName;
     private String contentType;
-    private Optional<String> subprotocol;
+    private Optional<String> subProtocol;
 
     public Builder(String target) {
       this.target = target;
       this.methodName = Optional.empty();
       this.contentType = "application/json";
       this.operationTypes = new HashSet<String>();
-      this.subprotocol = Optional.empty();
+      this.subProtocol = Optional.empty();
     }
 
     public Builder addOperationType(String operationType) {
@@ -122,14 +136,14 @@ public class Form {
       return this;
     }
 
-    public Builder addSubProtocol(String subprotocol) {
-      this.subprotocol = Optional.of(subprotocol);
+    public Builder addSubProtocol(String subProtocol) {
+      this.subProtocol = Optional.of(subProtocol);
       return this;
     }
 
     public Form build() {
       return new Form(this.target, this.methodName, this.contentType, this.operationTypes,
-        this.subprotocol);
+        this.subProtocol);
     }
 
   }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordance.java
@@ -66,6 +66,42 @@ public class InteractionAffordance {
     return Optional.empty();
   }
 
+  public boolean hasFormWithProtocol(String operationType, String protocol) {
+    return !forms.stream().filter(form -> form.hasOperationType(operationType)
+      && form.hasProtocol(protocol))
+      .collect(Collectors.toList()).isEmpty();
+  }
+
+  public Optional<Form> getFirstFormForProtocol(String operationType, String protocol) {
+    if (hasFormWithProtocol(operationType, protocol)) {
+      Form firstForm = forms.stream().filter(form -> form.hasOperationType(operationType)
+        && form.hasProtocol(protocol))
+        .collect(Collectors.toList()).get(0);
+
+      return Optional.of(firstForm);
+    }
+
+    return Optional.empty();
+  }
+
+  public boolean hasFormWithSubProtocol(String operationType, String subProtocol) {
+    return !forms.stream().filter(form -> form.hasOperationType(operationType)
+      && form.hasSubProtocol(operationType, subProtocol))
+      .collect(Collectors.toList()).isEmpty();
+  }
+
+  public Optional<Form> getFirstFormForSubProtocol(String operationType, String subProtocol) {
+    if (hasFormWithSubProtocol(operationType, subProtocol)) {
+      Form firstForm = forms.stream().filter(form -> form.hasOperationType(operationType)
+          && form.hasSubProtocol(operationType, subProtocol))
+        .collect(Collectors.toList()).get(0);
+
+      return Optional.of(firstForm);
+    }
+
+    return Optional.empty();
+  }
+
   public boolean hasSemanticType(String type) {
     return this.types.contains(type);
   }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/ProtocolBinding.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/affordances/ProtocolBinding.java
@@ -46,7 +46,7 @@ public final class ProtocolBinding {
     return Optional.empty();
   }
 
-  public static Optional<String> getDefaultSubprotocol(String href, String operationType) {
+  public static Optional<String> getDefaultSubProtocol(String href, String operationType) {
     if (getProtocol(href).isPresent()) {
       String protocol = getProtocol(href).get();
 

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/clients/TDCoapRequest.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/clients/TDCoapRequest.java
@@ -41,7 +41,7 @@ public class TDCoapRequest {
     this.form = form;
 
     Optional<String> methodName = form.getMethodName(operationType);
-    Optional<String> subprotocol = form.getSubprotocol(operationType);
+    Optional<String> subProtocol = form.getSubProtocol(operationType);
 
     if (methodName.isPresent()) {
       this.request = new Request(CoAP.Code.valueOf(methodName.get()));
@@ -51,7 +51,7 @@ public class TDCoapRequest {
         + operationType);
     }
 
-    if (subprotocol.isPresent() && subprotocol.get().equals(COV.observe)) {
+    if (subProtocol.isPresent() && subProtocol.get().equals(COV.observe)) {
       if (operationType.equals(TD.observeProperty)) {
         this.request.setObserve();
       }

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriter.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/io/TDGraphWriter.java
@@ -210,7 +210,7 @@ public class TDGraphWriter {
         }
       }
 
-      Optional<String> subProtocol = form.getSubprotocol();
+      Optional<String> subProtocol = form.getSubProtocol();
       if (subProtocol.isPresent()) {
         try {
           IRI subProtocolIri = rdf.createIRI(subProtocol.get());

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/InteractionAffordanceTest.java
@@ -1,6 +1,7 @@
 package ch.unisg.ics.interactions.wot.td.affordances;
 
 import ch.unisg.ics.interactions.wot.td.io.InvalidTDException;
+import ch.unisg.ics.interactions.wot.td.vocabularies.COV;
 import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,6 +9,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -21,13 +23,23 @@ public class InteractionAffordanceTest {
       .addOperationType(TD.readProperty)
       .build();
 
-    Form form2 = new Form.Builder("http://example.org/property2")
+    Form form2 = new Form.Builder("https://example.org/property2")
       .addOperationType(TD.writeProperty)
+      .build();
+
+    Form form3 = new Form.Builder("coap://example.org/property3")
+      .addOperationType(TD.observeProperty)
+      .addSubProtocol(COV.observe)
+      .build();
+
+    Form form4 = new Form.Builder("coaps://example.org/property4")
+      .addOperationType(TD.unobserveProperty)
+      .addSubProtocol(COV.observe)
       .build();
 
     test_affordance = new InteractionAffordance("my_affordance",
       Optional.of("My Affordance"), Arrays.asList(prefix + "Type1", prefix + "Type2"),
-      Arrays.asList(form1, form2));
+      Arrays.asList(form1, form2, form3, form4));
   }
 
   @Test(expected = InvalidTDException.class)
@@ -40,11 +52,108 @@ public class InteractionAffordanceTest {
   public void testHasFormForOperationType() {
     assertTrue(test_affordance.hasFormWithOperationType(TD.readProperty));
     assertTrue(test_affordance.hasFormWithOperationType(TD.writeProperty));
+    assertTrue(test_affordance.hasFormWithOperationType(TD.observeProperty));
+    assertTrue(test_affordance.hasFormWithOperationType(TD.unobserveProperty));
   }
 
   @Test
-  public void testNoFormByOperationType() {
+  public void testNoFormForOperationType() {
     assertFalse(test_affordance.hasFormWithOperationType("bla"));
+  }
+
+  @Test
+  public void testHasFormForSubprotocol() {
+    assertFalse(test_affordance.hasFormWithSubProtocol(TD.readProperty, COV.observe));
+    assertFalse(test_affordance.hasFormWithSubProtocol(TD.writeProperty, COV.observe));
+    assertTrue(test_affordance.hasFormWithSubProtocol(TD.observeProperty, COV.observe));
+    assertTrue(test_affordance.hasFormWithSubProtocol(TD.unobserveProperty, COV.observe));
+  }
+
+  @Test
+  public void testGetFirstFormForSubProtocol() {
+    Optional<Form> observeForm1 = test_affordance.getFirstFormForSubProtocol(TD.readProperty,
+      COV.observe);
+    Optional<Form> observeForm2 = test_affordance.getFirstFormForSubProtocol(TD.writeProperty,
+      COV.observe);
+    Optional<Form> observeForm3 = test_affordance.getFirstFormForSubProtocol(TD.observeProperty,
+      COV.observe);
+    Optional<Form> observeForm4 = test_affordance.getFirstFormForSubProtocol(TD.unobserveProperty,
+      COV.observe);
+
+    assertFalse(observeForm1.isPresent());
+    assertFalse(observeForm2.isPresent());
+    assertTrue(observeForm3.isPresent());
+    assertTrue(observeForm4.isPresent());
+
+    assertEquals(observeForm3.get().getTarget(),"coap://example.org/property3");
+    assertEquals(observeForm4.get().getTarget(),"coaps://example.org/property4");
+  }
+
+  @Test
+  public void testHasFormForProtocol() {
+    assertTrue(test_affordance.hasFormWithProtocol(TD.readProperty, "HTTP"));
+    assertTrue(test_affordance.hasFormWithProtocol(TD.writeProperty, "HTTP"));
+    assertTrue(test_affordance.hasFormWithProtocol(TD.observeProperty, "CoAP"));
+    assertTrue(test_affordance.hasFormWithProtocol(TD.unobserveProperty, "CoAP"));
+  }
+
+  @Test
+  public void testHasNoFormForProtocol() {
+    assertFalse(test_affordance.hasFormWithProtocol(TD.observeProperty, "HTTP"));
+    assertFalse(test_affordance.hasFormWithProtocol(TD.readProperty, "CoAP"));
+    assertFalse(test_affordance.hasFormWithProtocol(TD.writeProperty, "CoAP"));
+  }
+
+  @Test
+  public void testGetFirstFormForHttpProtocol() {
+    Optional<Form> httpForm1 = test_affordance.getFirstFormForProtocol(TD.readProperty,
+      "HTTP");
+    Optional<Form> httpForm2 = test_affordance.getFirstFormForProtocol(TD.writeProperty,
+      "HTTP");
+    Optional<Form> httpForm3 = test_affordance.getFirstFormForProtocol(TD.observeProperty,
+      "HTTP");
+    Optional<Form> httpForm4 = test_affordance.getFirstFormForSubProtocol(TD.unobserveProperty,
+      "HTTP");
+
+    assertTrue(httpForm1.isPresent());
+    assertTrue(httpForm2.isPresent());
+    assertFalse(httpForm3.isPresent());
+    assertFalse(httpForm4.isPresent());
+
+    assertTrue(httpForm1.get().getProtocol().isPresent());
+    assertTrue(httpForm2.get().getProtocol().isPresent());
+
+    assertEquals(httpForm1.get().getProtocol().get(), "HTTP");
+    assertEquals(httpForm2.get().getProtocol().get(), "HTTP");
+
+    assertEquals(httpForm1.get().getTarget(),"http://example.org/property1");
+    assertEquals(httpForm2.get().getTarget(),"https://example.org/property2");
+  }
+
+  @Test
+  public void testGetFirstFormForCoapProtocol() {
+    Optional<Form> coapForm1 = test_affordance.getFirstFormForProtocol(TD.readProperty,
+      "CoAP");
+    Optional<Form> coapForm2 = test_affordance.getFirstFormForProtocol(TD.writeProperty,
+      "CoAP");
+    Optional<Form> coapForm3 = test_affordance.getFirstFormForProtocol(TD.observeProperty,
+      "CoAP");
+    Optional<Form> coapForm4 = test_affordance.getFirstFormForProtocol(TD.unobserveProperty,
+      "CoAP");
+
+    assertFalse(coapForm1.isPresent());
+    assertFalse(coapForm2.isPresent());
+    assertTrue(coapForm3.isPresent());
+    assertTrue(coapForm4.isPresent());
+
+    assertTrue(coapForm3.get().getProtocol().isPresent());
+    assertTrue(coapForm4.get().getProtocol().isPresent());
+
+    assertEquals(coapForm3.get().getProtocol().get(), "CoAP");
+    assertEquals(coapForm4.get().getProtocol().get(), "CoAP");
+
+    assertEquals(coapForm3.get().getTarget(),"coap://example.org/property3");
+    assertEquals(coapForm4.get().getTarget(),"coaps://example.org/property4");
   }
 
   @Test

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/ProtocolBindingTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/affordances/ProtocolBindingTest.java
@@ -14,7 +14,7 @@ public class ProtocolBindingTest {
   public void testDefaultProtocolBinding() {
     String href = "coap://example.org/1";
     Optional<String> readPropertyMethodBinding = ProtocolBinding.getDefaultMethod(href, TD.readProperty);
-    Optional<String> readPropertySubprotocolBinding = ProtocolBinding.getDefaultSubprotocol(href,
+    Optional<String> readPropertySubprotocolBinding = ProtocolBinding.getDefaultSubProtocol(href,
       TD.readProperty);
 
     assertTrue(readPropertyMethodBinding.isPresent());
@@ -23,7 +23,7 @@ public class ProtocolBindingTest {
 
     Optional<String> observePropertyMethodBinding = ProtocolBinding.getDefaultMethod(href,
       TD.observeProperty);
-    Optional<String> observePropertySubprotocolBinding = ProtocolBinding.getDefaultSubprotocol(href,
+    Optional<String> observePropertySubprotocolBinding = ProtocolBinding.getDefaultSubProtocol(href,
       TD.observeProperty);
 
     assertTrue(observePropertyMethodBinding.isPresent());
@@ -36,7 +36,7 @@ public class ProtocolBindingTest {
   public void testUnknownUriScheme() {
     String href = "unknown://example.org/1";
     assertFalse(ProtocolBinding.getDefaultMethod(href, TD.readProperty).isPresent());
-    assertFalse(ProtocolBinding.getDefaultSubprotocol(href, TD.readProperty).isPresent());
+    assertFalse(ProtocolBinding.getDefaultSubProtocol(href, TD.readProperty).isPresent());
   }
 
   @Test
@@ -44,6 +44,6 @@ public class ProtocolBindingTest {
     String href = "http://example.org/1";
     String operationType = "http://example.org#unknownOp";
     assertFalse(ProtocolBinding.getDefaultMethod(href, operationType).isPresent());
-    assertFalse(ProtocolBinding.getDefaultSubprotocol(href, operationType).isPresent());
+    assertFalse(ProtocolBinding.getDefaultSubProtocol(href, operationType).isPresent());
   }
 }

--- a/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReaderTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/wot/td/io/TDGraphReaderTest.java
@@ -344,7 +344,7 @@ public class TDGraphReaderTest {
 
     Optional<Form> form = property.getFirstFormForOperationType(TD.readProperty);
     assertTrue(form.isPresent());
-    assertEquals("websub", form.get().getSubprotocol().get());
+    assertEquals("websub", form.get().getSubProtocol().get());
   }
 
   @Test
@@ -437,11 +437,11 @@ public class TDGraphReaderTest {
     assertEquals("GET", forms.get(0).getMethodName(TD.readProperty).get());
     assertEquals("GET", forms.get(1).getMethodName(TD.readProperty).get());
 
-    assertFalse(forms.get(0).getSubprotocol().isPresent());
-    assertFalse(forms.get(1).getSubprotocol().isPresent());
+    assertFalse(forms.get(0).getSubProtocol().isPresent());
+    assertFalse(forms.get(1).getSubProtocol().isPresent());
 
-    assertFalse(forms.get(0).getSubprotocol(TD.readProperty).isPresent());
-    assertFalse(forms.get(1).getSubprotocol(TD.readProperty).isPresent());
+    assertFalse(forms.get(0).getSubProtocol(TD.readProperty).isPresent());
+    assertFalse(forms.get(1).getSubProtocol(TD.readProperty).isPresent());
   }
 
   @Test
@@ -484,11 +484,11 @@ public class TDGraphReaderTest {
     assertEquals("PUT", forms.get(0).getMethodName(TD.writeProperty).get());
     assertEquals("PUT", forms.get(1).getMethodName(TD.writeProperty).get());
 
-    assertFalse(forms.get(0).getSubprotocol().isPresent());
-    assertFalse(forms.get(1).getSubprotocol().isPresent());
+    assertFalse(forms.get(0).getSubProtocol().isPresent());
+    assertFalse(forms.get(1).getSubProtocol().isPresent());
 
-    assertFalse(forms.get(0).getSubprotocol(TD.writeProperty).isPresent());
-    assertFalse(forms.get(1).getSubprotocol(TD.writeProperty).isPresent());
+    assertFalse(forms.get(0).getSubProtocol(TD.writeProperty).isPresent());
+    assertFalse(forms.get(1).getSubProtocol(TD.writeProperty).isPresent());
   }
 
   @Test
@@ -524,9 +524,9 @@ public class TDGraphReaderTest {
     assertTrue(form.get().getMethodName(TD.observeProperty).isPresent());
     assertEquals("GET", form.get().getMethodName(TD.observeProperty).get());
 
-    assertFalse(form.get().getSubprotocol().isPresent());
-    assertTrue(form.get().getSubprotocol(TD.observeProperty).isPresent());
-    assertEquals(COV.observe, form.get().getSubprotocol(TD.observeProperty).get());
+    assertFalse(form.get().getSubProtocol().isPresent());
+    assertTrue(form.get().getSubProtocol(TD.observeProperty).isPresent());
+    assertEquals(COV.observe, form.get().getSubProtocol(TD.observeProperty).get());
   }
 
   @Test
@@ -562,9 +562,9 @@ public class TDGraphReaderTest {
     assertTrue(form.get().getMethodName(TD.unobserveProperty).isPresent());
     assertEquals("GET", form.get().getMethodName(TD.unobserveProperty).get());
 
-    assertFalse(form.get().getSubprotocol().isPresent());
-    assertTrue(form.get().getSubprotocol(TD.unobserveProperty).isPresent());
-    assertEquals(COV.observe, form.get().getSubprotocol(TD.unobserveProperty).get());
+    assertFalse(form.get().getSubProtocol().isPresent());
+    assertTrue(form.get().getSubProtocol(TD.unobserveProperty).isPresent());
+    assertEquals(COV.observe, form.get().getSubProtocol(TD.unobserveProperty).get());
   }
 
   @Test(expected = InvalidTDException.class)
@@ -635,8 +635,8 @@ public class TDGraphReaderTest {
     Form formHTTP = property.getFirstFormForOperationType(TD.readProperty).get();
     Form formCoAP = property.getFirstFormForOperationType(TD.observeProperty).get();
 
-    assertEquals(COV.observe, formCoAP.getSubprotocol().get());
-    assertEquals("websub", formHTTP.getSubprotocol().get());
+    assertEquals(COV.observe, formCoAP.getSubProtocol().get());
+    assertEquals("websub", formHTTP.getSubProtocol().get());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -666,7 +666,7 @@ public class TDGraphReaderTest {
     Optional<Form> form = property.getFirstFormForOperationType(TD.writeProperty);
     assertTrue(form.isPresent());
 
-    form.get().getSubprotocol(TD.observeProperty);
+    form.get().getSubProtocol(TD.observeProperty);
   }
 
   @Test


### PR DESCRIPTION
Retrive form by protocol and subprotocol.

#### New methods on `InteractionAffordance`:
- `boolean hasFormWithProtocol(String operationType, String protocol)`
- `Optional<Form> getFirstFormForProtocol(String operationType, String protocol)`
- `boolean hasFormWithSubProtocol(String operationType, String subProtocol)`
- `Optional<Form> getFirstFormForSubProtocol(String operationType, String subProtocol)`

(They are created respectively to `hasFormWithOperationType` and `getFirstFormForOperationType`.

#### New method on `Form`:
`boolean hasProtocol(String protocol)` (useful values `protocol = "HTTP"` or `protocol = "CoAP"`)

#### Additional
Fixed typos "subprotocol" -> "subProtocol"