### PR TITLE
fix(tdhttpresponse) rm isPayloadNull

### DIFF
--- a/src/main/java/ch/unisg/ics/interactions/wot/td/clients/TDHttpResponse.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/clients/TDHttpResponse.java
@@ -135,8 +135,4 @@ public class TDHttpResponse {
     JsonElement content = JsonParser.parseString(payload.get());
     return schema.parseJson(content);
   }
-
-  public boolean isPayloadNull() {
-    return true;
-  }
 }


### PR DESCRIPTION
Removes `TDHttpResponse.isPayloadNull()` as the class offers a `public Optional<String> getPayload()` already.

Closes #202 