### PR TITLE
chore: remove try-catch requirement by using StandardCharsets

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  token: ecfaa8ba-6599-4bf2-b184-eff4db78ea21

--- a/src/main/java/ch/unisg/ics/interactions/wot/td/clients/UriTemplate.java
+++ b/src/main/java/ch/unisg/ics/interactions/wot/td/clients/UriTemplate.java
@@ -2,9 +2,10 @@ package ch.unisg.ics.interactions.wot.td.clients;
 
 import ch.unisg.ics.interactions.wot.td.schemas.DataSchema;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.*;
+import java.nio.charset.StandardCharsets;
+
 
 public class UriTemplate {
 
@@ -16,11 +17,7 @@ public class UriTemplate {
   }
 
   static List<String> extract(String path) {
-    try {
-      path = URLDecoder.decode(path, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
+    path = URLDecoder.decode(path, StandardCharsets.UTF_8);
     List<String> extracted = new ArrayList<>();
     int n = path.length();
     String s = "";


### PR DESCRIPTION
Using StandardCharsets removes the constraint to add a try-catch block. 