### PR TITLE
Fix version builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,6 @@ java {
   withSourcesJar()
 }
 
-version '0.1.1'
-
 repositories {
   mavenCentral()
 }
@@ -53,7 +51,6 @@ publishing {
       from components.java
       groupId 'ch.unisg.ics.interactions'
       artifactId 'wot-td-java'
-      version '0.1.1'
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ apply plugin: 'jacoco'
 apply plugin: 'maven-publish'
 apply plugin: 'idea'
 
+// Set version: use CLI parameter if provided, otherwise use git-based default
+version = findProperty('version') ?: 'master-SNAPSHOT'
+
 java {
   sourceCompatibility = JavaVersion.VERSION_21
   targetCompatibility = JavaVersion.VERSION_21
@@ -47,7 +50,7 @@ jacocoTestReport {
 
 publishing {
   publications {
-    ai4industry(MavenPublication) {
+    maven(MavenPublication) {
       from components.java
       groupId 'ch.unisg.ics.interactions'
       artifactId 'wot-td-java'


### PR DESCRIPTION
The build file contained a hard-coded default version that was overriding CLI parameters — and in turn interfered with Jitpack. This should fix the issue.